### PR TITLE
feat: add /macro, /swarm-status, /macro/override ClawBot Panel endpoints

### DIFF
--- a/backend/app/api/v1/openclaw.py
+++ b/backend/app/api/v1/openclaw.py
@@ -1,21 +1,27 @@
 """
-OpenClaw Bridge API — Phase 2 (DB-backed)
-POST /signals    → ingest batch from OpenClaw PC1
-GET  /signals/latest → latest scored signals (DB query)
-GET  /health     → bridge health + DB stats
-"""
+OpenClaw Bridge API — Phase 2.1 (DB-backed + ClawBot Panel endpoints)
 
+POST /signals      → ingest batch from OpenClaw PC1
+GET  /signals/latest → latest scored signals (DB query)
+GET  /health       → bridge health + DB stats
+GET  /macro        → Macro Brain state (wave gauge + regime)
+GET  /swarm-status → active clawbot team count and states
+POST /macro/override → operator bias slider adjustment
+"""
 import hashlib
 import json
+import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Literal, Optional
 
+import httpx
 from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from app.core.config import settings
 from app.services.openclaw_db import openclaw_db
 
+logger = logging.getLogger(__name__)
 router = APIRouter(tags=["openclaw"])
 
 
@@ -73,11 +79,48 @@ class SignalOut(BaseModel):
 
 class HealthOut(BaseModel):
     status: str
-    bridge_version: str = "2.0"
+    bridge_version: str = "2.1"
     total_ingests: int
     total_signals: int
     last_ingest: Optional[Dict] = None
     signals_last_24h: int
+
+
+# -- ClawBot Panel schemas (Phase 2.1) ----------------------------------------
+
+class MacroOut(BaseModel):
+    """Macro Brain state for wave gauge + regime banner."""
+    oscillator: float = 0.0
+    wave_state: str = "NEUTRAL"
+    bias: float = 1.0
+    regime: str = "YELLOW"
+    vix: Optional[float] = None
+    hy_spread: Optional[float] = None
+    fear_greed_index: Optional[int] = None
+
+
+class SwarmTeamOut(BaseModel):
+    id: str
+    status: str
+    agents: List[str] = []
+
+
+class SwarmStatusOut(BaseModel):
+    """Active clawbot team count and states."""
+    active: int = 0
+    total: int = 0
+    teams: List[SwarmTeamOut] = []
+
+
+class MacroOverrideIn(BaseModel):
+    """Operator bias slider adjustment."""
+    bias_multiplier: float = Field(..., ge=0.0, le=5.0)
+
+
+class MacroOverrideOut(BaseModel):
+    success: bool
+    bias_multiplier: float
+    message: str
 
 
 # -- auth helper --------------------------------------------------------------
@@ -110,7 +153,45 @@ def _row_to_signal(row: Dict) -> Dict:
     return out
 
 
-# -- endpoints ----------------------------------------------------------------
+async def _proxy_get(path: str) -> Optional[Dict]:
+    """Forward a GET request to OpenClaw PC1 and return JSON or None."""
+    base = settings.OPENCLAW_API_URL
+    if not base:
+        return None
+    url = f"{base.rstrip('/')}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            headers = {}
+            if settings.OPENCLAW_BRIDGE_TOKEN:
+                headers["X-OpenClaw-Token"] = settings.OPENCLAW_BRIDGE_TOKEN
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as exc:
+        logger.warning("proxy GET %s failed: %s", url, exc)
+        return None
+
+
+async def _proxy_post(path: str, body: Dict) -> Optional[Dict]:
+    """Forward a POST request to OpenClaw PC1 and return JSON or None."""
+    base = settings.OPENCLAW_API_URL
+    if not base:
+        return None
+    url = f"{base.rstrip('/')}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            headers = {"Content-Type": "application/json"}
+            if settings.OPENCLAW_BRIDGE_TOKEN:
+                headers["X-OpenClaw-Token"] = settings.OPENCLAW_BRIDGE_TOKEN
+            resp = await client.post(url, json=body, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as exc:
+        logger.warning("proxy POST %s failed: %s", url, exc)
+        return None
+
+
+# -- endpoints (existing) -----------------------------------------------------
 
 @router.post("/signals", response_model=IngestOut)
 async def ingest_openclaw_signals(
@@ -122,6 +203,7 @@ async def ingest_openclaw_signals(
 
     regime_dict = payload.regime.model_dump() if payload.regime else None
     universe_dict = payload.universe
+
     ingest_id = openclaw_db.insert_ingest(
         run_id=payload.run_id,
         timestamp=payload.timestamp.isoformat(),
@@ -145,12 +227,10 @@ async def get_latest_signals(
 ):
     """Return the most recent OpenClaw signals from DB."""
     _check_token(x_openclaw_token)
-
     if symbol:
         rows = openclaw_db.get_signals_by_symbol(symbol, limit=limit)
     else:
         rows = openclaw_db.get_latest_signals(limit=limit)
-
     return [_row_to_signal(r) for r in rows]
 
 
@@ -159,7 +239,6 @@ async def bridge_health():
     """Bridge health check — no auth required."""
     last = openclaw_db.get_latest_ingest()
     since_24h = (datetime.utcnow() - timedelta(hours=24)).isoformat() + "Z"
-
     history = openclaw_db.get_ingest_history(limit=1000)
     total_ingests = len(history)  # cheap for now
     total_signals = openclaw_db.count_signals()
@@ -180,4 +259,90 @@ async def bridge_health():
         total_signals=total_signals,
         last_ingest=last,
         signals_last_24h=signals_24h,
+    )
+
+
+# -- ClawBot Panel endpoints (Phase 2.1) --------------------------------------
+
+@router.get("/macro", response_model=MacroOut)
+async def get_macro_state(
+    x_openclaw_token: Optional[str] = Header(default=None),
+):
+    """
+    Macro Brain state for the wave gauge + regime banner.
+
+    Proxies to OpenClaw PC1 /api/v1/openclaw/macro when OPENCLAW_API_URL is
+    configured.  Falls back to the latest regime data stored in the local
+    ingest DB so the frontend always gets *something*.
+    """
+    _check_token(x_openclaw_token)
+
+    # --- try live data from PC1 first ---
+    live = await _proxy_get("/api/v1/openclaw/macro")
+    if live:
+        return MacroOut(**live)
+
+    # --- fallback: derive from latest ingest regime stored in DB ---
+    last = openclaw_db.get_latest_ingest()
+    if last:
+        regime_json = last.get("regime_json")
+        regime = json.loads(regime_json) if regime_json else {}
+        return MacroOut(
+            oscillator=regime.get("confidence", 0.0),
+            wave_state=regime.get("source", "NEUTRAL"),
+            bias=1.0,
+            regime=regime.get("state", "YELLOW"),
+        )
+
+    # --- no data at all ---
+    return MacroOut()
+
+
+@router.get("/swarm-status", response_model=SwarmStatusOut)
+async def get_swarm_status(
+    x_openclaw_token: Optional[str] = Header(default=None),
+):
+    """
+    Active clawbot team count and states.
+
+    Proxies to OpenClaw PC1 /api/v1/openclaw/swarm-status.  Returns an empty
+    swarm payload when PC1 is unreachable so the frontend can still render.
+    """
+    _check_token(x_openclaw_token)
+
+    live = await _proxy_get("/api/v1/openclaw/swarm-status")
+    if live:
+        return SwarmStatusOut(**live)
+
+    # --- offline fallback ---
+    return SwarmStatusOut()
+
+
+@router.post("/macro/override", response_model=MacroOverrideOut)
+async def macro_override(
+    body: MacroOverrideIn,
+    x_openclaw_token: Optional[str] = Header(default=None),
+):
+    """
+    Operator bias slider adjustment.
+
+    Forwards the bias_multiplier to OpenClaw PC1 which applies it to the
+    composite scorer in real-time.  Returns an error if PC1 is unreachable
+    since the override must actually take effect.
+    """
+    _check_token(x_openclaw_token)
+
+    result = await _proxy_post(
+        "/api/v1/openclaw/macro/override",
+        {"bias_multiplier": body.bias_multiplier},
+    )
+    if result:
+        return MacroOverrideOut(**result)
+
+    raise HTTPException(
+        status_code=503,
+        detail=(
+            "OpenClaw PC1 is unreachable — cannot apply bias override. "
+            "Ensure OPENCLAW_API_URL is configured and PC1 is running."
+        ),
     )


### PR DESCRIPTION
Phase 2.1: Add 3 missing ClawBot Panel endpoints per CLAWBOT_PANEL_DESIGN.md spec.

- GET /api/v1/openclaw/macro - Macro Brain state (oscillator, wave_state, bias, regime, vix, hy_spread, fear_greed_index)
- GET /api/v1/openclaw/swarm-status - Active clawbot team count and states
- POST /api/v1/openclaw/macro/override - Operator bias slider adjustment

All 3 endpoints proxy to OpenClaw PC1 when OPENCLAW_API_URL is configured. /macro falls back to DB regime data; /swarm-status returns empty payload; /macro/override returns 503 when PC1 unreachable.

Also adds httpx async client for PC1 proxy, new Pydantic schemas, and bumps bridge_version to 2.1.