### PR TITLE
fix: remove stray character breaking frontend CI build

### DIFF
--- a/frontend-v2/src/pages/DataSourcesMonitor.jsx
+++ b/frontend-v2/src/pages/DataSourcesMonitor.jsx
@@ -6,7 +6,7 @@ import {
   X,
   Copy,
   RefreshCw,
-  Settings,h
+  Settings,
   Check,
   XCircle,
   Loader2,


### PR DESCRIPTION
## Summary
- Removes a stray `h` character on line 9 of `DataSourcesMonitor.jsx` (`Settings,h` → `Settings,`)
- This 1-character typo has been causing **all CI runs to fail** on main and every open PR since commit `a3ab64c`
- Backend tests already pass — this unblocks Gate 2

## Context
Found during a full roadmap-vs-code audit. The `frontend-build` job fails with:
```
Expected "}" but found "Check"
frontend-v2/src/pages/DataSourcesMonitor.jsx:10:2
```

## Test plan
- [ ] CI `frontend-build` job passes (vite build succeeds)
- [ ] PR #34 CI should also go green once this merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)