### PR TITLE
fix: Full startup cleanup — Embodier Trader rename, Dockerfile, CORS, scripts, docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# =========== Elite Trading System .env Configuration (PRODUCTION) ===========
-# Copy this to .env and fill in your real API keys.
-# All API keys are REQUIRED for full production functionality.
+# =========== Embodier Trader — Root .env ===========
+# This file is for docker-compose and root-level scripts.
+# For backend config, see backend/.env.example (copy to backend/.env).
+# Only the settings below are needed at root level.
 
 # =========== ALPACA (LIVE TRADING) ===========
 ALPACA_API_KEY=your-alpaca-live-api-key

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,59 +1,74 @@
-# Embodier Trader - Setup & Quick Start Guide
+# Embodier Trader — Setup & Quick Start
 
-## System Requirements
-- Python 3.10+
-- Node.js 18+
+## Requirements
+- Python 3.10+ (with pip)
+- Node.js 18+ (with npm)
 - Git
 - Windows 10/11 (PowerShell 5.1+)
 
-## Verified Paths (ESPENMAIN PC)
+## Paths
+
+### ESPENMAIN (PC1 — Primary)
 ```
 Repo:      C:\Users\Espen\elite-trading-system
 Backend:   C:\Users\Espen\elite-trading-system\backend
 Frontend:  C:\Users\Espen\elite-trading-system\frontend-v2
-Desktop:   C:\Users\Espen\elite-trading-system\desktop
-Python:    C:\Users\Espen\elite-trading-system\backend\.venv
+Python:    C:\Users\Espen\elite-trading-system\backend\venv
 ```
 
-## Verified Paths (ProfitTrader PC)
+### ProfitTrader (PC2 — Secondary)
 ```
-Repo:      C:\Users\ProfitTrader\elite-trading-system  (clone if missing)
+Repo:      C:\Users\ProfitTrader\elite-trading-system
 ```
-
 
 ## Network (Two-PC LAN)
 
 | Machine | Hostname | LAN IP | Role |
 |---------|----------|--------|------|
-| PC1 | ESPENMAIN | 192.168.1.105 | Primary - backend, frontend, DB |
-| PC2 | ProfitTrader | 192.168.1.116 | Secondary - GPU training, ML |
+| PC1 | ESPENMAIN | 192.168.1.105 | Primary — backend, frontend, DB |
+| PC2 | ProfitTrader | 192.168.1.116 | Secondary — GPU training, ML |
 
-Both IPs are DHCP-reserved (fixed) on the AT&T BGW320-505 router (192.168.1.254).
+Both IPs are DHCP-reserved on the AT&T BGW320-505 router (192.168.1.254).
 
-> **Full details:** [docs/NETWORK_TWO_PC_SETUP.md](docs/NETWORK_TWO_PC_SETUP.md)
-> **AI/Coding rules:** [docs/AI_TWO_PC_CODING_GUIDE.md](docs/AI_TWO_PC_CODING_GUIDE.md)
+> See also: [docs/NETWORK_TWO_PC_SETUP.md](docs/NETWORK_TWO_PC_SETUP.md) and [docs/AI_TWO_PC_CODING_GUIDE.md](docs/AI_TWO_PC_CODING_GUIDE.md)
+
 ## Ports
-| Service       | Port  | URL                          |
-|--------------|-------|------------------------------|
-| Backend API  | 8000  | http://localhost:8000        |
-| API Docs     | 8000  | http://localhost:8000/docs   |
-| Frontend     | 3000  | http://localhost:3000        |
 
-## Quick Start (One Command)
+| Service | Port | URL |
+|---------|------|-----|
+| Backend API | 8000 | http://localhost:8000 |
+| API Docs | 8000 | http://localhost:8000/docs |
+| Frontend | 3000 | http://localhost:3000 |
+
+## Quick Start (One Click)
+
+Double-click `start-embodier.bat` or run:
 ```powershell
-# Right-click > Run with PowerShell
 cd C:\Users\Espen\elite-trading-system
 .\start-embodier.ps1
 ```
 
-## Manual Start (Step by Step)
-```powershell
-# 1. Backend
-cd C:\Users\Espen\elite-trading-system\backend
-.venv\Scripts\Activate.ps1
-uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+This will:
+1. Create a Python venv and install deps (first run only)
+2. Start the FastAPI backend on port 8000
+3. Install npm packages and start Vite on port 3000 (first run only)
+4. Open http://localhost:3000 in your browser
+5. Auto-restart if either service crashes (up to 3 times)
 
-# 2. Frontend (new terminal)
+### Backend only (no frontend)
+```powershell
+.\start-embodier.ps1 -SkipFrontend
+```
+
+## Manual Start (Step by Step)
+
+```powershell
+# Terminal 1 — Backend
+cd C:\Users\Espen\elite-trading-system\backend
+venv\Scripts\Activate.ps1
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+# Terminal 2 — Frontend
 cd C:\Users\Espen\elite-trading-system\frontend-v2
 npm run dev
 ```
@@ -61,18 +76,37 @@ npm run dev
 ## Environment Files
 
 ### backend/.env (required)
+Copy `backend/.env.example` to `backend/.env` and fill in your API keys.
+
+The minimum to get started:
 ```env
 ALPACA_API_KEY=your_key
 ALPACA_SECRET_KEY=your_secret
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
 TRADING_MODE=paper
-BACKEND_PORT=8000
+PORT=8000
 ```
 
-### frontend-v2/.env (optional, defaults work)
+### frontend-v2/.env (optional)
+The frontend proxy is configured in `vite.config.js` to forward `/api` requests
+to `http://localhost:8000` automatically. No `.env` needed for local dev.
+
+Set these only for production builds:
 ```env
 VITE_API_URL=http://localhost:8000
 VITE_WS_URL=ws://localhost:8000/ws
+```
+
+## Docker (Alternative)
+
+```bash
+# Copy and configure .env
+cp backend/.env.example backend/.env
+# Edit backend/.env with your API keys
+
+docker-compose up -d
+# Backend: http://localhost:8000
+# Frontend: http://localhost:3000
 ```
 
 ## Troubleshooting
@@ -87,28 +121,45 @@ Get-Process -Name python -ErrorAction SilentlyContinue | Stop-Process -Force
 ```powershell
 cd C:\Users\Espen\elite-trading-system
 git stash; git pull origin main; git stash drop
-cd backend; .venv\Scripts\Activate.ps1; pip install -r requirements.txt
+cd backend; venv\Scripts\Activate.ps1; pip install -r requirements.txt
 cd ..\frontend-v2; npm install
 cd ..; .\start-embodier.ps1
 ```
 
-### Verify API is running
+### Check if the API is running
 ```powershell
-Invoke-RestMethod http://localhost:8000/api/v1/health
-Invoke-RestMethod http://localhost:8000/api/v1/signals
+Invoke-RestMethod http://localhost:8000/health
+Invoke-RestMethod http://localhost:8000/api/v1/status
 ```
+
+### Check logs
+```
+logs\backend.log
+logs\frontend.log
+```
+
+### Common issues
+
+| Symptom | Fix |
+|---------|-----|
+| "python not found" | Install Python 3.10+ and add to PATH |
+| "npm not found" | Install Node.js 18+ from nodejs.org |
+| Backend won't start | Check `backend/.env` exists with valid Alpaca keys |
+| Frontend blank page | Make sure backend is running on port 8000 |
+| CORS errors | Backend auto-allows localhost origins — should work out of the box |
+| Port in use | The launcher auto-kills stale processes on ports 8000/3000 |
 
 ## Sync to ProfitTrader PC
 ```powershell
 # On ProfitTrader:
 cd C:\Users\ProfitTrader\elite-trading-system
 git pull origin main
-cd backend; .venv\Scripts\Activate.ps1; pip install -r requirements.txt
+cd backend; venv\Scripts\Activate.ps1; pip install -r requirements.txt
 cd ..\frontend-v2; npm install
-.\start-embodier.ps1
+cd ..; .\start-embodier.ps1
 ```
 
-## Create Desktop Shortcut
+## Desktop Shortcut
 ```powershell
 $ws = New-Object -ComObject WScript.Shell
 $s = $ws.CreateShortcut("$env:USERPROFILE\Desktop\Embodier Trader.lnk")

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,9 @@
-# Elite Trading System — Backend .env.example (PRODUCTION)
-# Copy to .env and fill in your real API keys. All features require valid keys.
+# Embodier Trader — Backend .env
+# Copy this file to .env and fill in your API keys.
+# Only ALPACA keys are required to start. Other services degrade gracefully.
 
 # ── App Settings ─────────────────────────────────────────
-APP_NAME=Elite Trading System API
+APP_NAME=Embodier Trader API
 APP_VERSION=4.0.0
 DEBUG=False
 LOG_LEVEL=INFO
@@ -164,8 +165,8 @@ LLM_DISPATCHER_HEARTBEAT_TIMEOUT=3
 LLM_DISPATCHER_FALLBACK_MODEL=llama3.2
 LLM_DISPATCHER_GPU_UTIL_THRESHOLD=85.0
 
-# ── Council (13-Agent Debate) ───────────────────────────
-# 8 core agents + 3 data-source perception agents + council gate + arbiter
+# ── Council (17-Agent Debate) ───────────────────────────
+# 7 perception + 5 technical + 5 decision agents + arbiter + CouncilGate + WeightLearner
 COUNCIL_ENABLED=true
 
 # ── OpenClaw (Multi-Agent Swarm) ────────────────────────

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,7 +32,7 @@ COPY --chown=appuser:appuser . .
 ENV PATH="/home/appuser/.local/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app \
-    TRADING_MODE=paper \  # Audit Task 4: default paper, never default to live
+    TRADING_MODE=paper \
     ENVIRONMENT=production
 
 # Switch to non-root user
@@ -41,7 +41,7 @@ USER appuser
 EXPOSE 8000
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=10s --retries=5 --start-period=120s  # Audit Task 20: 23+ services need time \
+HEALTHCHECK --interval=30s --timeout=10s --retries=5 --start-period=120s \
     CMD curl -f http://localhost:8000/health || exit 1
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/activate_venv.bat
+++ b/backend/activate_venv.bat
@@ -1,12 +1,9 @@
 @echo off
-echo Activating virtual environment...
+echo Activating Embodier Trader virtual environment...
 call venv\Scripts\activate.bat
-echo Virtual environment activated!
 echo.
-echo You can now run:
+echo Ready. You can now run:
 echo   python start_server.py
-echo   or
-echo   python tools/test_api.py
+echo   pytest tests/ -v
 echo.
 cmd /k
-

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,2 +1,2 @@
-# Elite Trading System Backend
+# Embodier Trader Backend
 

--- a/backend/app/api/v1/alignment.py
+++ b/backend/app/api/v1/alignment.py
@@ -72,7 +72,7 @@ def _load_audit(limit: int = 500) -> list:
 # ---------------------------------------------------------------------------
 _constitution = {
     "version": "1.0.0",
-    "text": """CONSTITUTION — Elite Trading System Alignment\n\n1. POSITION LIMITS: No single position > 5% of portfolio.\n2. DRAWDOWN GATE: Halt all new trades if drawdown > 10%.\n3. CORRELATION CAP: Max 3 correlated positions simultaneously.\n4. VOLATILITY FILTER: No entries when VIX > 35 unless hedged.\n5. STRATEGY MANDATE: Every trade must map to a registered strategy.\n6. AUDIT REQUIREMENT: All decisions logged immutably.""",
+    "text": """CONSTITUTION — Embodier Trader Alignment\n\n1. POSITION LIMITS: No single position > 5% of portfolio.\n2. DRAWDOWN GATE: Halt all new trades if drawdown > 10%.\n3. CORRELATION CAP: Max 3 correlated positions simultaneously.\n4. VOLATILITY FILTER: No entries when VIX > 35 unless hedged.\n5. STRATEGY MANDATE: Every trade must map to a registered strategy.\n6. AUDIT REQUIREMENT: All decisions logged immutably.""",
     "lastUpdated": datetime.now(timezone.utc).isoformat(),
 }
 

--- a/backend/app/api/v1/data_sources.py
+++ b/backend/app/api/v1/data_sources.py
@@ -1,5 +1,5 @@
 """
-Data Sources Manager - Elite Trading System
+Data Sources Manager - Embodier Trader
 backend/app/api/v1/data_sources.py
 
 Full CRUD, encrypted credentials, live connection testing,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,5 @@
 """
-Elite Trading System - Application Configuration
+Embodier Trader - Application Configuration
 All fields match EXACTLY what services reference via settings.FIELD_NAME
 """
 from pathlib import Path
@@ -20,8 +20,8 @@ class Settings(BaseSettings):
     )
 
     # ── App ─────────────────────────────────────────────────
-    APP_NAME: str = "Elite Trading System"
-    PROJECT_NAME: str = "Elite Trading System"
+    APP_NAME: str = "Embodier Trader"
+    PROJECT_NAME: str = "Embodier Trader"
     APP_VERSION: str = "4.0.0"  # Single source of truth for version
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
@@ -43,16 +43,15 @@ class Settings(BaseSettings):
 
     @property
     def effective_cors_origins(self) -> str:
-        """Return CORS origins based on environment.
-        Production: requires explicit CORS_ORIGINS env var.
-        Development: falls back to localhost origins.
+        """Return CORS origins.
+
+        Always includes localhost dev origins so the app works out of the box.
+        Add your production domain via CORS_ORIGINS env var.
         """
+        defaults = "http://localhost:5173,http://localhost:3000,http://localhost:3002,http://localhost:8501"
         if self.CORS_ORIGINS:
-            return self.CORS_ORIGINS
-        if self.ENVIRONMENT == "production":
-            return ""  # No CORS in production without explicit config
-        # Development defaults
-        return "http://localhost:5173,http://localhost:3000,http://localhost:3002,http://localhost:8501"
+            return f"{self.CORS_ORIGINS},{defaults}"
+        return defaults
 
     @property
     def effective_port(self) -> int:

--- a/backend/app/modules/__init__.py
+++ b/backend/app/modules/__init__.py
@@ -1,5 +1,5 @@
 """
-Modular components for the Elite Trading System.
+Modular components for the Embodier Trader.
 
 See MODULAR_ARCHITECTURE.md at repo root for the full design.
 - symbol_universe: Stock/symbol database and watchlists

--- a/backend/app/modules/ml_engine/xgboost_trainer.py
+++ b/backend/app/modules/ml_engine/xgboost_trainer.py
@@ -1,4 +1,4 @@
-"""XGBoost GPU trainer for Elite Trading System.
+"""XGBoost GPU trainer for Embodier Trader.
 
 APEX Phase 2 – XGBoost companion model:
 - GPU-accelerated training via tree_method='gpu_hist' (falls back to 'hist' on CPU)

--- a/backend/app/modules/openclaw/config.py
+++ b/backend/app/modules/openclaw/config.py
@@ -6,7 +6,7 @@ account data, order execution).  All agents read from / write to
 the in-process Blackboard via Pub/Sub topics.
 
 v6.0 additions:
-- Elite Trading System Bridge (PC2 GPU training integration)
+- Embodier Trader Bridge (PC2 GPU training integration)
 - 4-Agent Options Flow Pipeline (institutional sweep detection)
 - Darwinian Swarm meta-layer (self-evolving agent architecture)
 - Hunter-Killer Short Swarm (bear-side relative weakness)
@@ -276,7 +276,7 @@ WORLD_INTEL_CACHE_HOURS = int(os.getenv("WORLD_INTEL_CACHE_HOURS", "12"))
 
 # ============================================================
 #  ELITE TRADING SYSTEM BRIDGE (PC2 GPU Training)
-#  Connects OpenClaw swarm to the Elite Trading System on PC2
+#  Connects OpenClaw swarm to the Embodier Trader on PC2
 #  for GPU-accelerated model training and inference.
 # ============================================================
 ELITE_API_URL = os.getenv("ELITE_API_URL", "http://PC2_IP:8000")
@@ -450,7 +450,7 @@ _OPTIONAL_KEYS = [
     ("DISCORD_BOT_TOKEN",      DISCORD_BOT_TOKEN,      "Discord listener disabled"),
     ("GIST_TOKEN",             GIST_TOKEN,             "AI Bridge disabled"),
     ("OPENCLAW_DB_PATH", OPENCLAW_DB_PATH, "Database trade logging uses default path"),
-    ("ELITE_API_URL",           ELITE_API_URL,           "Elite Trading System bridge disabled"),
+    ("ELITE_API_URL",           ELITE_API_URL,           "Embodier Trader bridge disabled"),
   ("STOCKGEIST_TOKEN",        STOCKGEIST_TOKEN,        "StockGeist sentiment disabled"),
   ("NEWS_API_KEY",            NEWS_API_KEY,            "News API disabled"),
   ("X_BEARER_TOKEN",          X_BEARER_TOKEN,          "X/Twitter sentiment disabled"),

--- a/backend/app/modules/openclaw/integrations/bridge_sender.py
+++ b/backend/app/modules/openclaw/integrations/bridge_sender.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-bridge_sender.py - OpenClaw -> Elite Trading System Signal Sender
+bridge_sender.py - OpenClaw -> Embodier Trader Signal Sender
 
 Sends scored OpenClaw signals TO Elite's POST /openclaw/signals endpoint.
 This is the PC1 -> PC2 direction (complementing lstm_bridge_service.py
@@ -44,7 +44,7 @@ async def send_signals_to_elite(
     universe: Optional[Dict[str, Any]] = None,
     run_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Send a batch of scored signals to Elite Trading System."""
+    """Send a batch of scored signals to Embodier Trader."""
     if not signals:
         return {"run_id": None, "accepted": 0, "error": "No signals provided"}
 
@@ -75,7 +75,7 @@ async def send_signals_to_elite(
 
 
 async def check_elite_health() -> Dict[str, Any]:
-    """Check if Elite Trading System API is reachable."""
+    """Check if Embodier Trader API is reachable."""
     health_url = f"{ELITE_API_URL}{ELITE_API_PREFIX}/openclaw/health"
     async with httpx.AsyncClient(timeout=HTTPX_TIMEOUT) as client:
         resp = await client.get(health_url)

--- a/backend/app/modules/openclaw/integrations/lstm_bridge_service.py
+++ b/backend/app/modules/openclaw/integrations/lstm_bridge_service.py
@@ -3,7 +3,7 @@
 lstm_bridge_service.py - Elite LSTM -> OpenClaw Redis Bridge
 Apex Predator Convergence: Fusion Layer
 
-Standalone async daemon that continuously polls the Elite Trading System
+Standalone async daemon that continuously polls the Embodier Trader
 FastAPI backend for real-time LSTM predictions, publishes structured JSON
 to the Redis Blackboard channel `signals.ml_predictions`, and injects
 them into the ApexOrchestrator's ToT prompt context.
@@ -101,7 +101,7 @@ def _build_prediction_payload(signal: Dict) -> Dict:
 
 class LSTMBridgeService:
     """
-    Async daemon bridging Elite Trading System LSTM predictions
+    Async daemon bridging Embodier Trader LSTM predictions
     to the OpenClaw swarm via Redis pub/sub and the local Blackboard.
     """
 
@@ -356,7 +356,7 @@ class LSTMBridgeService:
         if not self._latest_predictions:
             return "LSTM PREDICTIONS: No predictions available from Elite system."
 
-        lines = ["LSTM PREDICTIONS (from Elite Trading System PyTorch model):"]
+        lines = ["LSTM PREDICTIONS (from Embodier Trader PyTorch model):"]
         for p in self._latest_predictions:
             lines.append(
                 f"  {p['ticker']}: direction={p['predicted_direction']} "

--- a/backend/app/modules/openclaw/scanner/earnings_calendar.py
+++ b/backend/app/modules/openclaw/scanner/earnings_calendar.py
@@ -1,5 +1,5 @@
 """
-Earnings Calendar Scanner - Elite Trading System
+Earnings Calendar Scanner - Embodier Trader
 Replaces yfinance earnings lookups with Finviz + SEC EDGAR.
 Uses finviz_service.py (already in stack) for earnings date data.
 """

--- a/backend/app/services/openclaw_bridge_service.py
+++ b/backend/app/services/openclaw_bridge_service.py
@@ -3,7 +3,7 @@ OpenClaw Bridge Service v2.1 — Real-time Signal Ingestion + Memory Intelligenc
 
 Architecture (2026.2.24):
   PC1 (OpenClaw scanner)
-    └─ bridge_sender.py  ──POST──►  PC2 (Elite Trading System)
+    └─ bridge_sender.py  ──POST──►  PC2 (Embodier Trader)
                                       └─ this file: openclaw_bridge_service.py
                                            ├─ Ring buffer (sub-second hot path)
                                            ├─ WebSocket broadcast → Agent Command Center

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -1,6 +1,6 @@
 """Settings service — DuckDB-backed, migration-safe, real validation.
 
-Manages all settings for the Elite Trading System across 7 categories:
+Manages all settings for the Embodier Trader across 7 categories:
 trading, risk, dataSources, notifications, ml, agents, system.
 Persisted in DuckDB settings table with auto-creation.
 """

--- a/backend/setup_venv.bat
+++ b/backend/setup_venv.bat
@@ -1,5 +1,5 @@
 @echo off
-echo Setting up Elite Trading System Backend...
+echo Setting up Embodier Trader Backend...
 echo.
 
 REM Check if venv exists
@@ -23,9 +23,6 @@ pip install -r requirements.txt
 echo.
 echo Setup complete!
 echo.
-echo To activate the virtual environment in the future, run:
-echo   venv\Scripts\activate
-echo.
-echo Or use: start.bat to start the server
+echo To start the server, run: start.bat
+echo Or from the repo root: start-embodier.bat
 pause
-

--- a/backend/start.bat
+++ b/backend/start.bat
@@ -1,4 +1,4 @@
 @echo off
-echo Starting Elite Trading System Backend API...
+echo Starting Embodier Trader Backend API...
+call venv\Scripts\activate.bat
 python start_server.py
-

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,4 +1,4 @@
-"""Backend test suite for Elite Trading System.
+"""Backend test suite for Embodier Trader.
 
 Run with: pytest backend/tests/ -v
 """

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures for Elite Trading System tests."""
+"""Shared pytest fixtures for Embodier Trader tests."""
 import os
 import pytest
 from httpx import AsyncClient, ASGITransport

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,4 +1,4 @@
-"""First 22 tests for Elite Trading System API.
+"""First 22 tests for Embodier Trader API.
 Covers: health checks, signal engine, Kelly sizer, config, CORS.
 """
 import pytest
@@ -10,7 +10,7 @@ from app.core.config import settings
 # --- Test 1: App instance exists ---
 def test_app_exists():
     assert app is not None
-    assert app.title == settings.APP_NAME or app.title in ("Elite Trading System", "Embodier Trader")
+    assert app.title == settings.APP_NAME or app.title in ("Embodier Trader", "Embodier Trader")
 
 
 # --- Test 2: API version matches config ---

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -227,7 +227,7 @@ function showAbout() {
       `Memory: ${sys.totalMemoryGB} GB`,
       sys.isAppleSilicon ? "Apple Silicon: Yes" : "",
       "",
-      "AI-Powered Elite Trading Platform",
+      "AI-Powered Trading Platform",
       "11-Agent Council | Event-Driven Pipeline",
       "",
       "© 2026 Embodier.ai",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "embodier-trader",
   "version": "3.1.0",
-  "description": "Embodier Trading System — AI-Powered Elite Trading Platform",
+  "description": "Embodier Trading System — AI-Powered Trading Platform",
   "main": "main.js",
   "author": "Embodier.ai",
   "license": "UNLICENSED",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
-# Elite Trading System - Docker Compose
+# Embodier Trader — Docker Compose
 # Run: docker-compose up -d
-
-version: '3.8'
 
 networks:
   trading:
@@ -16,7 +14,7 @@ services:
   # ── Redis (Cross-PC Message Broker) ─────────────────────
   redis:
     image: redis:7-alpine
-    container_name: elite-redis
+    container_name: embodier-redis
     ports:
       - "6379:6379"
     volumes:
@@ -46,15 +44,15 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    container_name: elite-backend
+    container_name: embodier-backend
     ports:
       - "8000:8000"
     env_file:
       - ./backend/.env
     environment:
-      - TRADING_MODE=${TRADING_MODE:-paper}  # Audit Task 4: default to paper, require explicit opt-in for live
+      - TRADING_MODE=${TRADING_MODE:-paper}
       - ENVIRONMENT=production
-      - REDIS_URL=redis://redis:6379/0  # Auto-connect to cluster Redis
+      - REDIS_URL=redis://redis:6379/0
     volumes:
       - duckdb_data:/app/data
       - model_artifacts:/app/models/artifacts
@@ -69,7 +67,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 120s  # Audit Task 20: 23+ services with built-in delays need time
+      start_period: 120s
     deploy:
       resources:
         limits:
@@ -84,13 +82,14 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ── Frontend ────────────────────────────────────────────
   frontend:
     build:
       context: ./frontend-v2
       dockerfile: Dockerfile
       args:
         VITE_API_URL: ${VITE_API_URL:-}
-    container_name: elite-frontend
+    container_name: embodier-frontend
     ports:
       - "3000:80"
     depends_on:

--- a/frontend-v2/.env.example
+++ b/frontend-v2/.env.example
@@ -1,5 +1,6 @@
-# Elite Trading System — Frontend .env.example (PRODUCTION)
-# Copy to .env and fill in. Only VITE_* variables are exposed to the browser.
+# Embodier Trader — Frontend .env (optional)
+# For local dev, leave empty — Vite proxy handles /api forwarding automatically.
+# Only set these for production builds.
 
 # ── API Connection ───────────────────────────────────────
 # In dev mode, leave empty so Vite proxy forwards /api -> localhost:8000

--- a/frontend-v2/src/pages/RiskIntelligence.jsx
+++ b/frontend-v2/src/pages/RiskIntelligence.jsx
@@ -1,5 +1,5 @@
 // =============================================================================
-// RiskIntelligence.jsx — Elite Trading System
+// RiskIntelligence.jsx — Embodier Trader
 // Route: /risk | Section: Execution | Page 10
 // Rebuilt to match mockup 13-risk-intelligence.png
 // =============================================================================
@@ -869,7 +869,7 @@ export default function RiskIntelligence() {
         <span className="flex items-center gap-2">
           <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
           <Radio className="w-3 h-3 text-[#00D9FF]" />
-          Elite Trading System -- Risk Intelligence v2.0
+          Embodier Trader -- Risk Intelligence v2.0
         </span>
         <div className="flex items-center gap-4">
           <span className="flex items-center gap-1.5">

--- a/scripts/migrate_openclaw.ps1
+++ b/scripts/migrate_openclaw.ps1
@@ -1,4 +1,4 @@
-# migrate_openclaw.ps1 - Phase 1: Copy + Namespace OpenClaw into Elite Trading System (Windows)
+# migrate_openclaw.ps1 - Phase 1: Copy + Namespace OpenClaw into Embodier Trader (Windows)
 # Usage: Run from elite-trading-system root after cloning openclaw as sibling
 #   git clone https://github.com/Espenator/openclaw.git ..\openclaw
 #   git checkout feat/absorb-openclaw
@@ -16,7 +16,7 @@ if (-not (Test-Path $OpenClawDir)) {
     exit 1
 }
 
-Write-Host "=== Phase 1: Absorb OpenClaw into Elite Trading System ===" -ForegroundColor Green
+Write-Host "=== Phase 1: Absorb OpenClaw into Embodier Trader ===" -ForegroundColor Green
 Write-Host "Source: $OpenClawDir"
 Write-Host "Target: $Target"
 Write-Host ""

--- a/start-embodier.bat
+++ b/start-embodier.bat
@@ -1,5 +1,5 @@
 @echo off
-title Embodier Trader v3.2.0
+title Embodier Trader v4.0.0
 color 0A
 cd /d "%~dp0"
 powershell -ExecutionPolicy Bypass -File ".\start-embodier.ps1"

--- a/start-embodier.ps1
+++ b/start-embodier.ps1
@@ -1,36 +1,213 @@
-param([switch]$SkipFrontend,[int]$BackendPort=0,[int]$FrontendPort=0,[int]$MaxRestarts=5)
-$ErrorActionPreference="Continue"
-$R=Split-Path -Parent $MyInvocation.MyCommand.Path;$BD="$R\backend";$FD="$R\frontend-v2";$LD="$R\logs"
-if(!(Test-Path $LD)){New-Item -ItemType Directory $LD -Force|Out-Null}
-$ef="$BD\.env"
-function GE($k,$d){if(Test-Path $ef){$l=Get-Content $ef|Where-Object{$_ -match "^$k="};if($l){return($l -split "=",2)[1].Trim()}};$d}
-if($BackendPort -eq 0){$BackendPort=[int](GE "PORT" "8000")}
-if($FrontendPort -eq 0){$FrontendPort=[int](GE "FRONTEND_PORT" "3000")}
+<#
+.SYNOPSIS
+    Embodier Trader — One-click launcher for backend + frontend.
+.DESCRIPTION
+    Starts the FastAPI backend and Vite dev server, with auto-restart,
+    health checks, and clean shutdown on Ctrl+C.
+.PARAMETER SkipFrontend
+    Start backend only (useful for API-only work or ProfitTrader PC).
+.PARAMETER BackendPort
+    Override backend port (default: from .env PORT or 8000).
+.PARAMETER FrontendPort
+    Override frontend port (default: from .env FRONTEND_PORT or 3000).
+.PARAMETER MaxRestarts
+    Max restart attempts per service before giving up (default: 3).
+#>
+param(
+    [switch]$SkipFrontend,
+    [int]$BackendPort = 0,
+    [int]$FrontendPort = 0,
+    [int]$MaxRestarts = 3
+)
+
+$ErrorActionPreference = "Continue"
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BackendDir = "$Root\backend"
+$FrontendDir = "$Root\frontend-v2"
+$LogDir = "$Root\logs"
+$EnvFile = "$BackendDir\.env"
+
+# ── Ensure logs directory ──
+if (!(Test-Path $LogDir)) { New-Item -ItemType Directory $LogDir -Force | Out-Null }
+
+# ── Helper: read value from .env ──
+function Get-EnvValue($Key, $Default) {
+    if (Test-Path $EnvFile) {
+        $line = Get-Content $EnvFile | Where-Object { $_ -match "^$Key=" }
+        if ($line) { return ($line -split "=", 2)[1].Trim() }
+    }
+    return $Default
+}
+
+# ── Resolve ports ──
+if ($BackendPort -eq 0) { $BackendPort = [int](Get-EnvValue "PORT" "8000") }
+if ($FrontendPort -eq 0) { $FrontendPort = [int](Get-EnvValue "FRONTEND_PORT" "3000") }
+
+# ── Banner ──
 Write-Host ""
-Write-Host "  EMBODIER TRADER - Backend::$BackendPort | Frontend::$FrontendPort" -ForegroundColor Magenta
+Write-Host "  ╔══════════════════════════════════════════╗" -ForegroundColor DarkCyan
+Write-Host "  ║        EMBODIER TRADER  v4.0.0           ║" -ForegroundColor DarkCyan
+Write-Host "  ║  Backend :$BackendPort  |  Frontend :$FrontendPort        ║" -ForegroundColor DarkCyan
+Write-Host "  ╚══════════════════════════════════════════╝" -ForegroundColor DarkCyan
 Write-Host ""
-if(Test-Path $ef){$rb=[IO.File]::ReadAllBytes($ef);if($rb.Length -ge 3 -and $rb[0]-eq 0xEF -and $rb[1]-eq 0xBB -and $rb[2]-eq 0xBF){[IO.File]::WriteAllText($ef,[IO.File]::ReadAllText($ef,[Text.Encoding]::UTF8),(New-Object Text.UTF8Encoding($false)))}}
-elseif(Test-Path "$BD\.env.example"){Copy-Item "$BD\.env.example" $ef}
-@($BackendPort,$FrontendPort)|ForEach-Object{Get-NetTCPConnection -LocalPort $_ -EA SilentlyContinue|ForEach-Object{Stop-Process -Id $_.OwningProcess -Force -EA SilentlyContinue}};Start-Sleep 1
-Set-Location $BD
-if(!(Test-Path venv)){python -m venv venv}
+
+# ── Fix .env encoding (remove BOM if present) ──
+if (Test-Path $EnvFile) {
+    $bytes = [IO.File]::ReadAllBytes($EnvFile)
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+        [IO.File]::WriteAllText($EnvFile, [IO.File]::ReadAllText($EnvFile, [Text.Encoding]::UTF8), (New-Object Text.UTF8Encoding($false)))
+        Write-Host "  [fix] Removed BOM from .env" -ForegroundColor Yellow
+    }
+} elseif (Test-Path "$BackendDir\.env.example") {
+    Copy-Item "$BackendDir\.env.example" $EnvFile
+    Write-Host "  [setup] Created .env from .env.example — edit with your API keys" -ForegroundColor Yellow
+}
+
+# ── Kill any stale processes on our ports ──
+@($BackendPort, $FrontendPort) | ForEach-Object {
+    Get-NetTCPConnection -LocalPort $_ -ErrorAction SilentlyContinue | ForEach-Object {
+        Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue
+    }
+}
+Start-Sleep 1
+
+# ── Ensure Python venv exists ──
+Set-Location $BackendDir
+if (!(Test-Path "venv")) {
+    Write-Host "  [setup] Creating Python virtual environment..." -ForegroundColor Cyan
+    python -m venv venv
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  [ERROR] Failed to create venv. Is Python 3.10+ installed?" -ForegroundColor Red
+        Write-Host "          Download from https://python.org/downloads" -ForegroundColor Yellow
+        exit 1
+    }
+}
+
+# ── Activate venv and install deps if needed ──
 & .\venv\Scripts\Activate.ps1
-try{python -c "import fastapi" 2>&1|Out-Null}catch{};if($LASTEXITCODE-ne 0){pip install -r requirements.txt --quiet}
-try{python -c "import aiohttp" 2>&1|Out-Null}catch{};if($LASTEXITCODE-ne 0){pip install aiohttp --quiet}
-$bj=Start-Job -ScriptBlock{param($d,$p,$l,$m);Set-Location $d;& .\venv\Scripts\Activate.ps1;$env:PORT=$p;$env:PYTHONIOENCODING="utf-8";$env:PYTHONUNBUFFERED="1";$r=0;while($r-le$m){if($r-gt 0){"$(Get-Date -F 'HH:mm:ss') RESTART $r"|Tee-Object $l -Append;Start-Sleep 5};try{python start_server.py 2>&1|Tee-Object $l -Append}catch{"$_"|Tee-Object $l -Append};$r++}} -Arg $BD,$BackendPort,"$LD\backend.log",$MaxRestarts
-Write-Host "Waiting for backend..." -ForegroundColor Cyan -NoNewline
-$ok=$false;for($i=0;$i-lt 45;$i++){Start-Sleep 1;try{if((Invoke-WebRequest "http://localhost:$BackendPort/healthz" -TimeoutSec 2 -EA SilentlyContinue).StatusCode-eq 200){$ok=$true;break}}catch{};Write-Host "." -NoNewline}
-Write-Host "";if($ok){Write-Host "[OK] Backend http://localhost:$BackendPort" -ForegroundColor Green}else{Write-Host "[WARN] Check $LD\backend.log" -ForegroundColor Yellow}
-$fj=$null
-if(!$SkipFrontend){Set-Location $FD;if(!(Test-Path node_modules)){npm install --silent}
-$fj=Start-Job -ScriptBlock{param($d,$bp,$fp,$l,$m);Set-Location $d;$env:VITE_BACKEND_URL="http://localhost:$bp";$r=0;while($r-le$m){if($r-gt 0){"$(Get-Date -F 'HH:mm:ss') RESTART FE $r"|Tee-Object $l -Append;Start-Sleep 3};try{npx vite --port $fp --host 2>&1|Tee-Object $l -Append}catch{"$_"|Tee-Object $l -Append};$r++}} -Arg $FD,$BackendPort,$FrontendPort,"$LD\frontend.log",$MaxRestarts
-Start-Sleep 3;Write-Host "[OK] Frontend http://localhost:$FrontendPort" -ForegroundColor Green
-Start-Sleep 2;Start-Process "http://localhost:$FrontendPort"}
+$needInstall = $false
+try { python -c "import fastapi" 2>&1 | Out-Null } catch { $needInstall = $true }
+if ($LASTEXITCODE -ne 0) { $needInstall = $true }
+if ($needInstall) {
+    Write-Host "  [setup] Installing Python dependencies..." -ForegroundColor Cyan
+    pip install -r requirements.txt --quiet 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  [ERROR] pip install failed. Check requirements.txt" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# ── Start backend (as a background job with restart loop) ──
+$backendJob = Start-Job -ScriptBlock {
+    param($dir, $port, $logFile, $maxRestarts)
+    Set-Location $dir
+    & .\venv\Scripts\Activate.ps1
+    $env:PORT = $port
+    $env:PYTHONIOENCODING = "utf-8"
+    $env:PYTHONUNBUFFERED = "1"
+    $restarts = 0
+    while ($restarts -le $maxRestarts) {
+        if ($restarts -gt 0) {
+            "$(Get-Date -Format 'HH:mm:ss') [RESTART $restarts/$maxRestarts]" | Tee-Object $logFile -Append
+            Start-Sleep 5
+        }
+        try {
+            python start_server.py 2>&1 | Tee-Object $logFile -Append
+        } catch {
+            "$_" | Tee-Object $logFile -Append
+        }
+        $restarts++
+    }
+    "$(Get-Date -Format 'HH:mm:ss') [FATAL] Backend exceeded $maxRestarts restarts" | Tee-Object $logFile -Append
+} -ArgumentList $BackendDir, $BackendPort, "$LogDir\backend.log", $MaxRestarts
+
+# ── Wait for backend health ──
+Write-Host "  Waiting for backend" -ForegroundColor Cyan -NoNewline
+$healthy = $false
+for ($i = 0; $i -lt 60; $i++) {
+    Start-Sleep 1
+    try {
+        $response = Invoke-WebRequest "http://localhost:$BackendPort/health" -TimeoutSec 2 -ErrorAction SilentlyContinue
+        if ($response.StatusCode -eq 200) { $healthy = $true; break }
+    } catch { }
+    Write-Host "." -NoNewline
+}
 Write-Host ""
-Write-Host "  RUNNING | Ctrl+C to stop" -ForegroundColor Green
+if ($healthy) {
+    Write-Host "  [OK] Backend   http://localhost:$BackendPort" -ForegroundColor Green
+    Write-Host "       API Docs  http://localhost:$BackendPort/docs" -ForegroundColor DarkGray
+} else {
+    Write-Host "  [WARN] Backend may not be ready yet. Check logs\backend.log" -ForegroundColor Yellow
+    # Don't exit — it might still come up (23+ services take time)
+}
+
+# ── Start frontend (unless skipped) ──
+$frontendJob = $null
+if (!$SkipFrontend) {
+    Set-Location $FrontendDir
+
+    # Ensure node_modules
+    if (!(Test-Path "node_modules")) {
+        Write-Host "  [setup] Installing frontend dependencies..." -ForegroundColor Cyan
+        npm install --silent 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  [ERROR] npm install failed. Is Node.js 18+ installed?" -ForegroundColor Red
+            Write-Host "          Download from https://nodejs.org" -ForegroundColor Yellow
+        }
+    }
+
+    $frontendJob = Start-Job -ScriptBlock {
+        param($dir, $backendPort, $frontendPort, $logFile, $maxRestarts)
+        Set-Location $dir
+        $env:VITE_BACKEND_URL = "http://localhost:$backendPort"
+        $restarts = 0
+        while ($restarts -le $maxRestarts) {
+            if ($restarts -gt 0) {
+                "$(Get-Date -Format 'HH:mm:ss') [RESTART FE $restarts/$maxRestarts]" | Tee-Object $logFile -Append
+                Start-Sleep 3
+            }
+            try {
+                npx vite --port $frontendPort --host 2>&1 | Tee-Object $logFile -Append
+            } catch {
+                "$_" | Tee-Object $logFile -Append
+            }
+            $restarts++
+        }
+    } -ArgumentList $FrontendDir, $BackendPort, $FrontendPort, "$LogDir\frontend.log", $MaxRestarts
+
+    Start-Sleep 3
+    Write-Host "  [OK] Frontend  http://localhost:$FrontendPort" -ForegroundColor Green
+
+    # Open browser
+    Start-Sleep 2
+    Start-Process "http://localhost:$FrontendPort"
+}
+
+# ── Running banner ──
 Write-Host ""
-try{while($true){Start-Sleep 10;if($bj.State-eq"Failed"){Write-Host "Backend FAILED" -ForegroundColor Red;Receive-Job $bj;break}}}finally{
-if($bj){Stop-Job $bj -EA SilentlyContinue;Remove-Job $bj -EA SilentlyContinue}
-if($fj){Stop-Job $fj -EA SilentlyContinue;Remove-Job $fj -EA SilentlyContinue}
-@($BackendPort,$FrontendPort)|ForEach-Object{Get-NetTCPConnection -LocalPort $_ -EA SilentlyContinue|ForEach-Object{Stop-Process -Id $_.OwningProcess -Force -EA SilentlyContinue}}
-Write-Host "[OK] Stopped." -ForegroundColor Green}
+Write-Host "  RUNNING  |  Press Ctrl+C to stop" -ForegroundColor Green
+Write-Host "  Logs:  $LogDir\backend.log  /  frontend.log" -ForegroundColor DarkGray
+Write-Host ""
+
+# ── Monitor loop + clean shutdown ──
+try {
+    while ($true) {
+        Start-Sleep 10
+        if ($backendJob.State -eq "Failed") {
+            Write-Host "  [ERROR] Backend crashed. See logs\backend.log" -ForegroundColor Red
+            Receive-Job $backendJob
+            break
+        }
+    }
+} finally {
+    Write-Host ""
+    Write-Host "  Shutting down..." -ForegroundColor Yellow
+    if ($backendJob) { Stop-Job $backendJob -ErrorAction SilentlyContinue; Remove-Job $backendJob -ErrorAction SilentlyContinue }
+    if ($frontendJob) { Stop-Job $frontendJob -ErrorAction SilentlyContinue; Remove-Job $frontendJob -ErrorAction SilentlyContinue }
+    @($BackendPort, $FrontendPort) | ForEach-Object {
+        Get-NetTCPConnection -LocalPort $_ -ErrorAction SilentlyContinue | ForEach-Object {
+            Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue
+        }
+    }
+    Write-Host "  [OK] Stopped." -ForegroundColor Green
+}


### PR DESCRIPTION
## What this does

Full cleanup pass across 30 files to make the app start reliably from a desktop shortcut.

### Naming (25 files)
- `Elite Trading System` → `Embodier Trader` in all code, configs, scripts, Docker
- Docker containers: `elite-*` → `embodier-*`

### Startup fixes
- **Rewrote `start-embodier.ps1`**: clean banner, proper error messages, correct health endpoint (`/health`), graceful shutdown
- **Fixed Dockerfile**: inline comments broke `HEALTHCHECK` and `ENV` instructions
- **Fixed CORS**: production mode was returning empty string = no frontend access. Now always includes localhost dev origins
- **Fixed `backend/start.bat`**: wasn't activating venv before starting
- **Standardized venv** naming (`venv` everywhere, not `.venv`)

### Docs
- **Rewrote SETUP.md**: troubleshooting table, common issues, accurate paths
- Clarified only Alpaca keys needed to start (graceful degradation)
- Fixed .env.example headers and descriptions

### Other
- Removed deprecated docker-compose `version` key  
- Fixed 13→17 agent count in .env.example