### PR TITLE
fix: Startup blockers for Embodier Trader debut

### DIFF
--- a/backend/app/jobs/scheduler.py
+++ b/backend/app/jobs/scheduler.py
@@ -52,11 +52,10 @@ def start_scheduler() -> Optional[object]:
         The scheduler instance, or None if disabled/unavailable.
     """
     global _scheduler
-    import os
+    from app.core.config import settings
 
-    enabled = os.getenv("SCHEDULER_ENABLED", "false").lower() == "true"
-    if not enabled:
-        log.info("Scheduler disabled (SCHEDULER_ENABLED != true)")
+    if not settings.SCHEDULER_ENABLED:
+        log.info("Scheduler disabled (SCHEDULER_ENABLED=false in config)")
         return None
 
     try:

--- a/backend/run_server.py
+++ b/backend/run_server.py
@@ -15,7 +15,7 @@ import uvicorn
 
 
 def main():
-    host = os.getenv("HOST", "127.0.0.1")
+    host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8000"))
 
     uvicorn.run(


### PR DESCRIPTION
## Summary

Two targeted fixes to get the Embodier Trader backend fully operational for debut.

## Changes

### 1. Scheduler config fix (`backend/app/jobs/scheduler.py`)
- **Bug:** `start_scheduler()` used `os.getenv('SCHEDULER_ENABLED', 'false')` instead of `settings.SCHEDULER_ENABLED`
- **Impact:** The scheduler never started because the default was `'false'` via `os.getenv()`, even though `Settings.SCHEDULER_ENABLED = True` in config.py
- **Fix:** Now reads from `settings.SCHEDULER_ENABLED` (the pydantic Settings object), consistent with how every other module reads config

### 2. run_server.py host default (`backend/run_server.py`)
- **Bug:** Default HOST was `127.0.0.1` (localhost-only), blocking LAN access from PC2 (ProfitTrader)
- **Fix:** Changed default to `0.0.0.0`, matching `start_server.py` and `config.py` defaults

## Verification

Full startup verified — all services boot cleanly:
- `/health` → 200 (healthy, v4.0.0, council-controlled)
- `/healthz` → 200 (alive)
- `/api/v1/status` → 200 (ok, connected)
- `/docs` → 200 (Swagger UI loads)
- All 25 event-driven pipeline services start ✅
- All 33 API routers mounted (including alpaca.py) ✅
- Frontend builds clean (0 errors, code-split into 29 chunks) ✅

## Closes
Resolves acceptance criteria for #17 (Start backend for the first time)