### PR TITLE
fix(api): ingestion health returns 503 on error status, add regression tests

### DIFF
--- a/backend/app/api/ingestion.py
+++ b/backend/app/api/ingestion.py
@@ -53,10 +53,18 @@ async def run_backfill(req: BackfillRequest):
 
 @router.get("/health")
 async def ingestion_health():
-    """Check DuckDB health and table row counts. Returns 503 when unhealthy for readiness probes."""
+    """Check DuckDB health and table row counts. Returns 503 when unhealthy for readiness probes.
+    Never returns 200 with body {\"status\": \"error\"}; use 503 for any failure or degraded state.
+    """
     try:
         from app.data.duckdb_storage import duckdb_store
-        return duckdb_store.health_check()
+        result = duckdb_store.health_check()
+        # Never return 200 with status=error (readiness probes expect 503 on failure)
+        if isinstance(result, dict) and result.get("status") == "error":
+            raise HTTPException(status_code=503, detail="Ingestion/DuckDB unhealthy")
+        return result
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("ingestion_health failed: %s", e)
         raise HTTPException(status_code=503, detail="Ingestion/DuckDB unhealthy")

--- a/backend/tests/test_e2e_audit_enhancements.py
+++ b/backend/tests/test_e2e_audit_enhancements.py
@@ -34,6 +34,46 @@ class TestIngestionHealth503:
         if r.status_code == 503:
             assert "unhealthy" in (r.json().get("detail") or "").lower() or "503" in str(r.status_code)
 
+    def test_ingestion_health_returns_503_when_health_check_raises(self, client):
+        """When DuckDB health_check raises, endpoint must return 503 (not 500 or 200)."""
+        original_health = None
+        try:
+            from app.data import duckdb_storage
+            original_health = duckdb_storage.duckdb_store.health_check
+
+            def failing_health():
+                raise RuntimeError("DuckDB unavailable")
+
+            duckdb_storage.duckdb_store.health_check = failing_health
+            r = client.get("/api/ingestion/health")
+            assert r.status_code == 503
+            data = r.json()
+            assert "detail" in data
+            assert "unhealthy" in (data.get("detail") or "").lower()
+        finally:
+            if original_health is not None:
+                duckdb_storage.duckdb_store.health_check = original_health
+
+    def test_ingestion_health_returns_503_when_status_error_in_body(self, client):
+        """When health_check returns {\"status\": \"error\"}, endpoint must return 503."""
+        from app.data import duckdb_storage
+
+        original_health = None
+        try:
+            original_health = duckdb_storage.duckdb_store.health_check
+
+            def error_status_health():
+                return {"status": "error", "message": "degraded"}
+
+            duckdb_storage.duckdb_store.health_check = error_status_health
+            r = client.get("/api/ingestion/health")
+            assert r.status_code == 503
+            data = r.json()
+            assert "detail" in data
+        finally:
+            if original_health is not None:
+                duckdb_storage.duckdb_store.health_check = original_health
+
 
 class TestAgentsPayloadNormalized:
     """GET /agents must include statusDisplay, cpu, mem for frontend."""


### PR DESCRIPTION
## Summary
- Ingestion `/health` never returns 200 with body `{"status": "error"}`; raises 503 for readiness probes.
- If `health_check()` returns `status=error` or raises, endpoint returns 503 with "Ingestion/DuckDB unhealthy".
- Added `test_ingestion_health_returns_503_when_health_check_raises` and `test_ingestion_health_returns_503_when_status_error_in_body`.
- Preserves `HTTPException` in `ingestion_health` so 503 is not wrapped.

## Files changed
- `backend/app/api/ingestion.py` — 503 on error status, re-raise HTTPException
- `backend/tests/test_e2e_audit_enhancements.py` — 2 new regression tests

No council/arbiter changes. All E2E audit tests pass.
