### PR TITLE
Fix critical auth, WebSocket, polling, and UX (#33-54)

### DIFF
--- a/frontend-v2/src/components/ui/ConfirmDialog.jsx
+++ b/frontend-v2/src/components/ui/ConfirmDialog.jsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useCallback } from "react";
+
+/**
+ * Reusable confirmation modal for dangerous/destructive actions.
+ *
+ * Props:
+ *   open        – boolean, controls visibility
+ *   onConfirm   – called when user clicks Confirm
+ *   onCancel    – called when user clicks Cancel or presses Escape
+ *   title       – modal heading text
+ *   description – body text explaining the consequences
+ *   confirmText – label for the confirm button (default "Confirm")
+ *   variant     – "danger" (red confirm) or "warning" (amber confirm), default "danger"
+ */
+export default function ConfirmDialog({
+  open,
+  onConfirm,
+  onCancel,
+  title = "Are you sure?",
+  description = "",
+  confirmText = "Confirm",
+  variant = "danger",
+}) {
+  const cancelRef = useRef(null);
+  const dialogRef = useRef(null);
+
+  // Auto-focus Cancel button when dialog opens (safety: default action is cancel)
+  useEffect(() => {
+    if (open) {
+      // Small delay to ensure DOM is ready
+      const id = setTimeout(() => cancelRef.current?.focus(), 50);
+      return () => clearTimeout(id);
+    }
+  }, [open]);
+
+  // Close on Escape key
+  const handleKeyDown = useCallback(
+    (e) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel?.();
+      }
+      // Focus trap: Tab within the dialog
+      if (e.key === "Tab" && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [onCancel]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleKeyDown]);
+
+  if (!open) return null;
+
+  const confirmColors =
+    variant === "warning"
+      ? "bg-amber-600 hover:bg-amber-500 focus:ring-amber-500/50 text-white"
+      : "bg-red-600 hover:bg-red-500 focus:ring-red-500/50 text-white";
+
+  return (
+    <div
+      className="fixed inset-0 z-[9998] flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+    >
+      {/* Dark overlay backdrop */}
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+
+      {/* Modal */}
+      <div
+        ref={dialogRef}
+        className="relative z-10 w-full max-w-md mx-4 rounded-lg border border-[#1e293b] bg-[#111827] shadow-2xl shadow-black/50"
+      >
+        {/* Header */}
+        <div className="px-5 pt-5 pb-2">
+          <h2
+            id="confirm-dialog-title"
+            className="text-base font-bold text-white font-mono tracking-wide"
+          >
+            {title}
+          </h2>
+        </div>
+
+        {/* Body */}
+        {description && (
+          <div className="px-5 pb-4">
+            <p className="text-sm text-[#94a3b8] leading-relaxed">
+              {description}
+            </p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-[#1e293b] bg-[#0B0E14]/50 rounded-b-lg">
+          <button
+            ref={cancelRef}
+            onClick={onCancel}
+            className="px-4 py-2 text-sm font-medium text-[#94a3b8] bg-[#1e293b] hover:bg-[#374151] border border-[#374151] rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-[#64748b]/50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`px-4 py-2 text-sm font-bold rounded-md transition-colors focus:outline-none focus:ring-2 ${confirmColors}`}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-v2/src/config/api.js
+++ b/frontend-v2/src/config/api.js
@@ -283,14 +283,10 @@ export function getApiUrl(endpoint) {
  * @param {string} [channel] - WS topic/channel name
  */
 export function getWsUrl(channel) {
-  // In dev mode, prefer connecting via the Vite proxy (same host) so /ws proxy rules apply.
-  // Only use the hardcoded WS_URL if an explicit env var was set or we're not in a browser.
-  const explicitWsUrl = import.meta.env.VITE_WS_URL;
-  const base = explicitWsUrl
-    ? API_CONFIG.WS_URL
-    : (typeof window !== "undefined"
-        ? `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}`
-        : API_CONFIG.WS_URL);
+  // FIX #52: Always use the configured WS_URL (defaults to ws://localhost:8001).
+  // Previously fell back to window.location.host which resolved to Vite dev server
+  // (ws://localhost:5173) — the Vite WS proxy is unreliable for long-lived connections.
+  const base = API_CONFIG.WS_URL;
   const token = (typeof localStorage !== "undefined" && localStorage.getItem("auth_token")) ||
                 import.meta.env.VITE_API_AUTH_TOKEN || "";
   const wsBase = token ? `${base}/ws?token=${encodeURIComponent(token)}` : `${base}/ws`;
@@ -311,6 +307,22 @@ export function getAuthHeaders() {
     import.meta.env.VITE_API_AUTH_TOKEN ||
     null;
   return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Extract a user-friendly error message from a fetch response.
+ * Detects API_AUTH_TOKEN-not-configured (403) and shows a specific message.
+ */
+export async function extractApiError(res) {
+  const body = await res.json().catch(() => ({}));
+  const detail = body?.detail || body?.message || "";
+  if (res.status === 403 && typeof detail === "string" && detail.includes("API_AUTH_TOKEN")) {
+    return "API auth token not configured. Set API_AUTH_TOKEN in backend .env and VITE_API_AUTH_TOKEN in frontend .env, then restart both servers.";
+  }
+  if (res.status === 401) {
+    return "Authentication failed — check your API_AUTH_TOKEN matches between frontend and backend.";
+  }
+  return detail || `HTTP ${res.status}`;
 }
 
 /**

--- a/frontend-v2/src/hooks/useApi.js
+++ b/frontend-v2/src/hooks/useApi.js
@@ -45,8 +45,12 @@ function _releaseSlot() {
   _runNext();
 }
 
-// Per-URL in-flight deduplication
+// Per-URL in-flight deduplication + short-lived result cache (2s window)
+// _inflight: URL -> Promise (for concurrent in-flight requests)
+// _fetchCache: URL -> { promise, timestamp } (for near-simultaneous requests within DEDUP_WINDOW_MS)
 const _inflight = new Map();
+const _fetchCache = new Map();
+const DEDUP_WINDOW_MS = 2000;
 
 /**
  * Combine two AbortSignals without requiring AbortSignal.any (ES2023+).
@@ -101,6 +105,26 @@ export function useApi(endpoint, options = {}) {
       setError(new Error(`Unknown endpoint: ${endpoint}`));
       setLoading(false);
       return;
+    }
+
+    // Deduplicate: if same URL was fetched within DEDUP_WINDOW_MS, reuse result
+    const cached = _fetchCache.get(url);
+    if (cached && Date.now() - cached.timestamp < DEDUP_WINDOW_MS) {
+      try {
+        const json = await cached.promise;
+        if (!signal?.aborted) {
+          setData(json);
+          setError(null);
+          setIsStale(false);
+          setLastUpdated(Date.now());
+        }
+        return;
+      } catch {
+        if (signal?.aborted) return;
+        // Cache entry failed — fall through to fresh fetch
+      } finally {
+        if (!signal?.aborted) setLoading(false);
+      }
     }
 
     // Deduplicate: if same URL is already in-flight, piggyback on it
@@ -160,6 +184,8 @@ export function useApi(endpoint, options = {}) {
     })();
 
     _inflight.set(url, fetchPromise);
+    // Store in dedup cache so near-simultaneous requests share this result
+    _fetchCache.set(url, { promise: fetchPromise, timestamp: Date.now() });
     try {
       setError(null);
       const json = await fetchPromise;
@@ -170,11 +196,11 @@ export function useApi(endpoint, options = {}) {
       }
     } catch (err) {
       if (signal?.aborted) return;
-      const cached = _apiCache.get(url);
-      if (cached && Date.now() - cached.ts < CACHE_STALE_MS) {
-        setData(cached.data);
+      const staleCached = _apiCache.get(url);
+      if (staleCached && Date.now() - staleCached.ts < CACHE_STALE_MS) {
+        setData(staleCached.data);
         setIsStale(true);
-        setLastUpdated(cached.ts);
+        setLastUpdated(staleCached.ts);
       } else {
         setError(err);
       }

--- a/frontend-v2/src/hooks/useCNS.jsx
+++ b/frontend-v2/src/hooks/useCNS.jsx
@@ -34,8 +34,9 @@ export function CNSProvider({ children }) {
   const [circuitBreakerArmed, setCircuitBreakerArmed] = useState(true);
   const [circuitBreakerFired, setCircuitBreakerFired] = useState(null);
   const [latestVerdict, setLatestVerdict] = useState(null);
-  const [wsConnected, setWsConnected] = useState(false);
-  const [wsReconnecting, setWsReconnecting] = useState(false);
+  // Initialize from actual WS state so indicator is correct on mount
+  const [wsConnected, setWsConnected] = useState(() => ws.getState() === 'connected');
+  const [wsReconnecting, setWsReconnecting] = useState(() => ws.getState() === 'reconnecting');
 
   // Notification queue — components subscribe to this
   const [notifications, setNotifications] = useState([]);

--- a/frontend-v2/src/hooks/useTradeExecution.js
+++ b/frontend-v2/src/hooks/useTradeExecution.js
@@ -305,10 +305,13 @@ export default function useTradeExecution() {
     setError(null);
     try {
       await tradeExecutionService.closePosition(symbol, side);
-      setSystemStatus(prev => [{ time: new Date().toLocaleTimeString(), text: `Position closed: ${symbol} ${side}`, type: 'success' }, ...prev]);
+      const msg = `Position closed: ${symbol} ${side}`;
+      setSystemStatus(prev => [{ time: new Date().toLocaleTimeString(), text: msg, type: 'success' }, ...prev]);
+      toast.success(msg);
       await fetchAll();
     } catch (err) {
       setError(err.message);
+      toast.error(`Close position failed: ${err.message}`);
     } finally {
       setLoading(false);
     }
@@ -318,13 +321,17 @@ export default function useTradeExecution() {
     setLoading(true);
     setError(null);
     setSystemStatus(prev => [{ time: new Date().toLocaleTimeString(), text: `Adjusting position: ${symbol} ${side}`, type: 'info' }, ...prev]);
+    toast.info(`Adjusting position: ${symbol} ${side}`);
     try {
       await tradeExecutionService.adjustPosition(symbol, side, { action: 'scale' });
-      setSystemStatus(prev => [{ time: new Date().toLocaleTimeString(), text: `Position adjusted: ${symbol} ${side}`, type: 'success' }, ...prev]);
+      const msg = `Position adjusted: ${symbol} ${side}`;
+      setSystemStatus(prev => [{ time: new Date().toLocaleTimeString(), text: msg, type: 'success' }, ...prev]);
+      toast.success(msg);
       await fetchAll();
     } catch (err) {
       setError(err.message);
       setSystemStatus(prev => [{ time: new Date().toLocaleTimeString(), text: `Adjust failed: ${err.message}`, type: 'error' }, ...prev]);
+      toast.error(`Adjust position failed: ${err.message}`);
     } finally {
       setLoading(false);
     }

--- a/frontend-v2/src/pages/AgentCommandCenter.jsx
+++ b/frontend-v2/src/pages/AgentCommandCenter.jsx
@@ -10,6 +10,7 @@ import {
 import { useApi } from "../hooks/useApi";
 import { toast } from "react-toastify";
 import { getApiUrl, getAuthHeaders } from "../config/api";
+import ConfirmDialog from "../components/ui/ConfirmDialog";
 
 // Tab components (split for manageable file sizes)
 import SwarmOverviewTab from "./agent-tabs/SwarmOverviewTab";
@@ -49,6 +50,7 @@ export default function AgentCommandCenter() {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = searchParams.get("tab") || "overview";
   const [killSwitchActive, setKillSwitchActive] = useState(false);
+  const [showKillConfirm, setShowKillConfirm] = useState(false);
 
   // Data hooks (real API — no mock data)
   const { data: agentsRaw } = useApi("agents", { pollIntervalMs: 15000 });
@@ -59,7 +61,11 @@ export default function AgentCommandCenter() {
   const { data: driftRaw } = useApi("drift", { pollIntervalMs: 30000 });
   const { data: blackboardRaw } = useApi("cnsBlackboard", { pollIntervalMs: 15000 });
   const { data: cnsAgentsHealthRaw } = useApi("cnsAgentsHealth", { pollIntervalMs: 15000 });
-  const agents = useMemo(() => (Array.isArray(agentsRaw) ? agentsRaw : []), [agentsRaw]);
+  const agents = useMemo(() => {
+    if (Array.isArray(agentsRaw)) return agentsRaw;
+    if (agentsRaw?.agents && Array.isArray(agentsRaw.agents)) return agentsRaw.agents;
+    return [];
+  }, [agentsRaw]);
   const teams = useMemo(() => (Array.isArray(teamsRaw) ? teamsRaw : teamsRaw?.teams ?? []), [teamsRaw]);
   const alerts = useMemo(() => (Array.isArray(alertsRaw) ? alertsRaw : alertsRaw?.alerts ?? []), [alertsRaw]);
   const conferenceData = useMemo(() => conferenceRaw?.current ?? conferenceRaw?.conference ?? conferenceRaw ?? null, [conferenceRaw]);
@@ -142,35 +148,7 @@ export default function AgentCommandCenter() {
         <div className="flex items-center gap-4">
           <button
             className="px-4 py-1.5 text-[11px] font-bold bg-[#7f1d1d] text-[#f87171] border border-[#ef4444]/50 rounded-full hover:bg-[#991b1b] hover:shadow-[0_0_12px_rgba(239,68,68,0.3)] transition-all flex items-center gap-1.5 tracking-wider"
-            onClick={async () => {
-              if (!window.confirm("⚠️ KILL SWITCH: This will halt ALL trading, cancel ALL open orders, and shut down ALL agents. Are you sure?")) return;
-              toast.warning("KILL SWITCH activated — executing emergency shutdown...");
-              try {
-                const controller = new AbortController();
-                const timeout = setTimeout(() => controller.abort(), 15000);
-                const res = await fetch(getApiUrl("risk-shield/emergency-action"), {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json", ...getAuthHeaders() },
-                  body: JSON.stringify({ action: "kill_switch" }),
-                  signal: controller.signal,
-                });
-                clearTimeout(timeout);
-                if (res.ok) {
-                  const data = await res.json().catch(() => ({}));
-                  setKillSwitchActive(true);
-                  toast.error(`KILL SWITCH EXECUTED — orders cancelled: ${data.orders_cancelled ?? "yes"}, positions closed: ${data.positions_closed ?? "yes"}`);
-                } else {
-                  const err = await res.json().catch(() => ({}));
-                  toast.error(`KILL SWITCH FAILED: ${err?.detail || err?.message || `HTTP ${res.status}`} — manual intervention required`);
-                }
-              } catch (e) {
-                if (e.name === "AbortError") {
-                  toast.error("KILL SWITCH TIMED OUT — check system manually!");
-                } else {
-                  toast.error("KILL SWITCH FAILED: " + (e?.message || "network error") + " — manual intervention required");
-                }
-              }
-            }}
+            onClick={() => setShowKillConfirm(true)}
           >
             <Power className="w-3 h-3" />
             KILL SWITCH
@@ -248,6 +226,45 @@ export default function AgentCommandCenter() {
           Embodier.ai v2.0
         </div>
       </div>
+
+      {/* Kill Switch Confirmation Dialog */}
+      <ConfirmDialog
+        open={showKillConfirm}
+        onConfirm={async () => {
+          setShowKillConfirm(false);
+          toast.warning("KILL SWITCH activated — executing emergency shutdown...");
+          try {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 15000);
+            const res = await fetch(getApiUrl("risk-shield/emergency-action"), {
+              method: "POST",
+              headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+              body: JSON.stringify({ action: "kill_switch" }),
+              signal: controller.signal,
+            });
+            clearTimeout(timeout);
+            if (res.ok) {
+              const data = await res.json().catch(() => ({}));
+              setKillSwitchActive(true);
+              toast.error(`KILL SWITCH EXECUTED — orders cancelled: ${data.orders_cancelled ?? "yes"}, positions closed: ${data.positions_closed ?? "yes"}`);
+            } else {
+              const err = await res.json().catch(() => ({}));
+              toast.error(`KILL SWITCH FAILED: ${err?.detail || err?.message || `HTTP ${res.status}`} — manual intervention required`);
+            }
+          } catch (e) {
+            if (e.name === "AbortError") {
+              toast.error("KILL SWITCH TIMED OUT — check system manually!");
+            } else {
+              toast.error("KILL SWITCH FAILED: " + (e?.message || "network error") + " — manual intervention required");
+            }
+          }
+        }}
+        onCancel={() => setShowKillConfirm(false)}
+        title="KILL SWITCH"
+        description="This will halt ALL trading, cancel ALL open orders, and shut down ALL agents. This action cannot be undone. Are you sure?"
+        confirmText="Activate Kill Switch"
+        variant="danger"
+      />
 
       {/* KILL SWITCH overlay */}
       {killSwitchActive && (

--- a/frontend-v2/src/pages/Dashboard.jsx
+++ b/frontend-v2/src/pages/Dashboard.jsx
@@ -1,12 +1,13 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import log from "@/utils/logger";
 import { useApi } from "../hooks/useApi";
-import { getApiUrl, getAuthHeaders } from "../config/api";
+import { getApiUrl, getAuthHeaders, extractApiError } from "../config/api";
 import CNSVitals from "../components/dashboard/CNSVitals";
 import ProfitBrainBar from "../components/dashboard/ProfitBrainBar";
 import ws from "../services/websocket";
+import ConfirmDialog from "../components/ui/ConfirmDialog";
 
 // --- TOP TICKER STRIP (scrolling market tickers) ---
 const TickerStrip = ({ indices, signals, snapshots = {} }) => {
@@ -805,6 +806,9 @@ export default function Dashboard() {
   const [dirFilter, setDirFilter] = useState("ALL"); // "ALL", "LONG", "SHORT"
   const [activeTimeframe, setActiveTimeframe] = useState("1h");
   const [autoExec, setAutoExec] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [showFlattenConfirm, setShowFlattenConfirm] = useState(false);
+  const [showEmergencyConfirm, setShowEmergencyConfirm] = useState(false);
 
   // --- WebSocket connection (Layout owns lifecycle, this is just a safety-net connect) ---
   useEffect(() => {
@@ -813,40 +817,81 @@ export default function Dashboard() {
     // Calling ws.disconnect() here kills the connection for all pages.
   }, []);
 
+  // --- SIGNALS FETCH (manual, with timeframe support) ---
+  // FIX #38: Manual fetch so timeframe changes trigger immediate re-fetch
+  //          using getApiUrl("signals") for correct base URL.
+  const [signalsData, setSignalsData] = useState(null);
+  const [sigLoading, setSigLoading] = useState(true);
+  const [sigErr, setSigErr] = useState(null);
+  const [sigStale, setSigStale] = useState(false);
+  const signalsAbortRef = useRef(null);
+
+  const fetchSignals = useCallback(async (signal) => {
+    const url = `${getApiUrl("signals")}?timeframe=${encodeURIComponent(activeTimeframe)}`;
+    try {
+      const res = await fetch(url, {
+        cache: "no-store",
+        headers: getAuthHeaders(),
+        signal,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      const json = await res.json();
+      if (!signal?.aborted) {
+        setSignalsData(json);
+        setSigErr(null);
+        setSigStale(false);
+      }
+    } catch (err) {
+      if (signal?.aborted || err.name === "AbortError") return;
+      setSigErr(err);
+    } finally {
+      if (!signal?.aborted) setSigLoading(false);
+    }
+  }, [activeTimeframe]);
+
+  // Re-fetch immediately when timeframe changes
+  useEffect(() => {
+    if (signalsAbortRef.current) signalsAbortRef.current.abort();
+    const ctrl = new AbortController();
+    signalsAbortRef.current = ctrl;
+    setSigLoading(true);
+    fetchSignals(ctrl.signal);
+    return () => ctrl.abort();
+  }, [fetchSignals]);
+
+  // Poll signals every 5s (HIGH: real-time trading signals)
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (document.hidden) return;
+      fetchSignals(signalsAbortRef.current?.signal);
+    }, 5000);
+    return () => clearInterval(id);
+  }, [fetchSignals]);
+
   // --- API HOOKS (Real-time polling) ---
-  // Intervals tuned to prevent request flooding (max ~2 req/s combined)
-  const {
-    data: signalsData,
-    loading: sigLoading,
-    error: sigErr,
-    isStale: sigStale,
-  } = useApi("signals", {
-    pollIntervalMs: 15000,
-    endpoint: `/signals/?timeframe=${encodeURIComponent(activeTimeframe)}`,
-  });
-  const { data: kellyData, error: kellyErr } = useApi("kellyRanked", { pollIntervalMs: 30000 });
-  const { data: portfolioData, error: portfolioErr } = useApi("portfolio", { pollIntervalMs: 15000 });
+  const { data: kellyData, error: kellyErr } = useApi("kellyRanked", { pollIntervalMs: 30000 }); // LOW: position sizing
+  const { data: portfolioData, error: portfolioErr } = useApi("portfolio", { pollIntervalMs: 5000 }); // HIGH: real-time portfolio
   const { data: indicesData, error: indicesErr } = useApi("marketIndices", {
-    pollIntervalMs: 15000,
+    pollIntervalMs: 5000,  // HIGH: real-time prices
   });
-  const { data: openclawData, error: openclawErr } = useApi("openclaw", { pollIntervalMs: 30000 });
+  const { data: openclawData, error: openclawErr } = useApi("openclaw", { pollIntervalMs: 30000 }); // LOW: regime data
   const { data: performanceData } = useApi("performance", {
-    pollIntervalMs: 60000,
+    pollIntervalMs: 60000,  // LOW: historical perf
   });
-  const { data: agentsData } = useApi("agents", { pollIntervalMs: 30000 });
-  const { data: consensusData } = useApi("agentConsensus", { pollIntervalMs: 20000 });
-  const { data: performanceEquityData } = useApi("performanceEquity", { pollIntervalMs: 30000 });
+  const { data: agentsData } = useApi("agents", { pollIntervalMs: 15000 }); // MEDIUM: agent status
+  const { data: consensusData } = useApi("agentConsensus", { pollIntervalMs: 15000 }); // MEDIUM: consensus
+  const { data: performanceEquityData } = useApi("performanceEquity", { pollIntervalMs: 60000 }); // LOW: equity curve
   const { data: riskScoreData } = useApi("riskScore", {
-    pollIntervalMs: 30000,
+    pollIntervalMs: 15000,  // MEDIUM: risk score
   });
   const { data: alertsData } = useApi("systemAlerts", {
-    pollIntervalMs: 30000,
+    pollIntervalMs: 15000,  // MEDIUM: alerts
   });
-  const { data: flywheelData } = useApi("flywheel", { pollIntervalMs: 60000 });
+  const { data: flywheelData } = useApi("flywheel", { pollIntervalMs: 60000 }); // LOW: flywheel
   const { data: sentimentData } = useApi("sentiment", {
-    pollIntervalMs: 30000,
+    pollIntervalMs: 30000,  // LOW: sentiment
   });
-  const { data: cognitiveData } = useApi("cognitiveDashboard", { pollIntervalMs: 30000 });
+  const { data: cognitiveData } = useApi("cognitiveDashboard", { pollIntervalMs: 60000 }); // LOW: cognitive
 
   // Right Panel specific APIs based on selectedSymbol
   const { data: techsData } = useApi("signals", {
@@ -866,7 +911,7 @@ export default function Dashboard() {
   });
   const { data: quotesData } = useApi("quotes", {
     endpoint: `/quotes/${selectedSymbol}/book`,
-    pollIntervalMs: 10000,
+    pollIntervalMs: 5000,  // HIGH: real-time order book for selected symbol
     enabled: !!selectedSymbol,
   });
 
@@ -988,8 +1033,9 @@ export default function Dashboard() {
       .catch((e) => {
         if (e.name !== "AbortError") log.warn("Ticker snapshot fetch failed:", e);
       });
-    // Refresh every 15s
+    // Refresh every 15s, pause when tab is hidden
     const interval = setInterval(() => {
+      if (document.hidden) return;
       fetch(url, { headers: getAuthHeaders() })
         .then((r) => r.json())
         .then((data) => {
@@ -1062,10 +1108,9 @@ export default function Dashboard() {
     try {
       const res = await fetch(getApiUrl("signals"), { method: "POST", headers: { "Content-Type": "application/json", ...getAuthHeaders() } });
       if (!res.ok) {
-        const detail = await res.json().catch(() => ({}));
-        const msg = detail?.detail || detail?.message || `HTTP ${res.status}`;
+        const msg = await extractApiError(res);
         log.error("Scan failed:", msg);
-        toast?.error?.(`Scan failed: ${msg}`);
+        toast.error(`Scan failed: ${msg}`);
         return;
       }
       const data = await res.json().catch(() => ({}));
@@ -1105,42 +1150,69 @@ export default function Dashboard() {
       toast.warning(`Top 5: ${ok} placed, ${failed} failed`);
     }
   }, [processedSignals]);
-  const handleFlatten = useCallback(async () => {
-    if (!window.confirm("Flatten ALL positions? This cannot be undone.")) return;
+  const doFlatten = useCallback(async () => {
     try {
       const res = await fetch(getApiUrl("orders") + "/flatten-all", { method: "POST", headers: getAuthHeaders() });
-      if (!res.ok) { toast.error(`Flatten failed: HTTP ${res.status}`); return; }
+      if (!res.ok) { const msg = await extractApiError(res); toast.error(`Flatten failed: ${msg}`); return; }
       toast.success("All positions flattened");
     } catch (e) {
       log.error(e);
       toast.error(`Flatten error: ${e.message}`);
     }
   }, []);
-  const handleEmergencyStop = useCallback(async () => {
-    if (!window.confirm("EMERGENCY STOP: Cancel all orders and close all positions?")) return;
+  const handleFlatten = useCallback(() => setShowFlattenConfirm(true), []);
+  const doEmergencyStop = useCallback(async () => {
     try {
       const res = await fetch(getApiUrl("orders") + "/emergency-stop", { method: "POST", headers: getAuthHeaders() });
-      if (!res.ok) { toast.error(`Emergency stop failed: HTTP ${res.status}`); return; }
+      if (!res.ok) { const msg = await extractApiError(res); toast.error(`Emergency stop failed: ${msg}`); return; }
       toast.success("Emergency stop executed");
     } catch (e) {
       log.error(e);
       toast.error(`Emergency stop error: ${e.message}`);
     }
   }, []);
+  const handleEmergencyStop = useCallback(() => setShowEmergencyConfirm(true), []);
 
+  // FIX #36: Export CSV with proper feedback, loading state, and error handling
   const handleExportCSV = useCallback(() => {
-    const data = processedSignals;
-    if (!data.length) { toast.warn("No signals to export"); return; }
-    const headers = ["symbol","direction","score","entry","target","stop","rMultiple","kellyPercent"];
-    const rows = data.map(s => headers.map(h => `"${s[h] ?? ""}"`).join(","));
-    const csv = [headers.join(","), ...rows].join("\n");
-    const blob = new Blob([csv], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const fname = `signals_export_${new Date().toISOString().slice(0, 10)}.csv`;
-    const a = document.createElement("a"); a.href = url; a.download = fname; a.click();
-    URL.revokeObjectURL(url);
-    toast.success(`Exported ${data.length} signals`);
-  }, [processedSignals]);
+    try {
+      setIsExporting(true);
+      const data = displaySignals;
+      if (!data.length) { toast.warn("No signals to export"); setIsExporting(false); return; }
+      const headers = ["symbol","direction","score","regime","ml","sentiment","technical","entry","target","stop","rMultiple","kellyPercent","momentum","volSpike","pattern"];
+      const headerLabels = ["Symbol","Direction","Score","Regime","ML","Sentiment","Technical","Entry","Target","Stop","R-Multiple","Kelly %","Momentum","Vol Spike","Pattern"];
+      const getField = (sig, h) => {
+        switch (h) {
+          case "regime": return sig.scores?.regime ?? "";
+          case "ml": return sig.scores?.ml ?? "";
+          case "sentiment": return sig.scores?.sentiment ?? "";
+          case "technical": return sig.scores?.technical ?? "";
+          default: return sig[h] ?? "";
+        }
+      };
+      // CSV escape: wrap in quotes and escape internal quotes
+      const esc = (v) => `"${String(v).replace(/"/g, '""')}"`;
+      const rows = data.map(s => headers.map(h => esc(getField(s, h))).join(","));
+      const csv = [headerLabels.join(","), ...rows].join("\n");
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const fname = `signals_export_${activeTimeframe}_${new Date().toISOString().slice(0, 10)}.csv`;
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fname;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast.success(`Exported ${data.length} signals to CSV`);
+    } catch (err) {
+      log.error("CSV export failed:", err);
+      toast.error(`CSV export failed: ${err.message || "unknown error"}`);
+    } finally {
+      // Brief loading state so user sees feedback
+      setTimeout(() => setIsExporting(false), 600);
+    }
+  }, [displaySignals, activeTimeframe]);
 
   const handleSpawnAgent = useCallback(() => {
     navigate("/agents");
@@ -1429,11 +1501,12 @@ export default function Dashboard() {
                 <button
                   key={tf}
                   onClick={() => setActiveTimeframe(tf)}
-                  className={`px-1.5 py-0.5 rounded-sm text-[8px] ${activeTimeframe === tf ? "bg-[#1e293b] text-white" : "hover:bg-[#1e293b]/50"}`}
+                  className={`px-1.5 py-0.5 rounded-sm text-[8px] transition-colors ${activeTimeframe === tf ? "bg-[#1e293b] text-white font-bold" : "hover:bg-[#1e293b]/50"}`}
                 >
                   {tf}
                 </button>
               ))}
+              {sigLoading && <span className="text-[7px] text-[#00D9FF] animate-pulse ml-1">loading...</span>}
             </div>
             <div className="flex items-center gap-3 text-[8px]">
               <button
@@ -1557,8 +1630,8 @@ export default function Dashboard() {
             <button onClick={handleRunScan} className="bg-[#1e293b] hover:bg-[#374151] text-white px-3 py-1 rounded text-[8px] font-mono border border-[#374151]">
               Run Scan [F5]
             </button>
-            <button onClick={handleExportCSV} className="bg-[#1e293b] hover:bg-[#374151] text-white px-3 py-1 rounded text-[8px] font-mono border border-[#374151]">
-              Export CSV [F7]
+            <button onClick={handleExportCSV} disabled={isExporting} className={`px-3 py-1 rounded text-[8px] font-mono border transition-colors ${isExporting ? "bg-[#00D9FF]/20 text-[#00D9FF] border-[#00D9FF]/50 cursor-wait" : "bg-[#1e293b] hover:bg-[#374151] text-white border-[#374151]"}`}>
+              {isExporting ? "Exporting..." : "Export CSV [F7]"}
             </button>
             <button onClick={handleExecTop5} className="bg-cyan-900/60 hover:bg-cyan-800 text-[#00D9FF] px-3 py-1 rounded text-[8px] font-mono border border-cyan-700/50">
               Exec Top 5
@@ -1903,6 +1976,26 @@ export default function Dashboard() {
         .ticker-glow { animation: ticker-glow 2s ease-in-out infinite; }
       `,
         }}
+      />
+
+      {/* Confirmation Dialogs */}
+      <ConfirmDialog
+        open={showFlattenConfirm}
+        onConfirm={() => { setShowFlattenConfirm(false); doFlatten(); }}
+        onCancel={() => setShowFlattenConfirm(false)}
+        title="Flatten All Positions"
+        description="This will close ALL open positions at market price. This cannot be undone. Are you sure?"
+        confirmText="Flatten All"
+        variant="warning"
+      />
+      <ConfirmDialog
+        open={showEmergencyConfirm}
+        onConfirm={() => { setShowEmergencyConfirm(false); doEmergencyStop(); }}
+        onCancel={() => setShowEmergencyConfirm(false)}
+        title="Emergency Stop"
+        description="This will halt all trading activity immediately, cancel all open orders, and close all positions. Are you sure?"
+        confirmText="Emergency Stop"
+        variant="danger"
       />
     </div>
   );

--- a/frontend-v2/src/pages/Settings.jsx
+++ b/frontend-v2/src/pages/Settings.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useSettings } from "../hooks/useSettings";
 import { useApi } from "../hooks/useApi";
+import { getAuthHeaders } from "../config/api";
 import { toast } from "react-toastify";
 import {
   User, Key, Activity, Bell, Cpu, Database,
@@ -320,6 +321,14 @@ export default function SettingsPage() {
           {saving ? "Saving..." : "SAVE ALL"}
         </button>
       </div>
+
+      {/* Auth Token Status */}
+      {!getAuthHeaders().Authorization && (
+        <div className="rounded-lg p-3 mb-2 bg-amber-900/30 border border-amber-500/40 text-amber-300 text-sm flex items-center gap-2">
+          <span className="font-bold">⚠ Setup Required:</span>
+          <span>API_AUTH_TOKEN not configured. Set it in backend/.env and VITE_API_AUTH_TOKEN in frontend-v2/.env to enable trading actions.</span>
+        </div>
+      )}
 
       {/* ROW 1: Identity & Locale, Trading Mode, Position Rules, Risk Limits, Circuit Breakers */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-2 mb-2">

--- a/frontend-v2/src/pages/SignalIntelligenceV3.jsx
+++ b/frontend-v2/src/pages/SignalIntelligenceV3.jsx
@@ -533,13 +533,15 @@ export default function SignalIntelligenceV3() {
       setChartError(false);
       try {
         const url =
-          getApiUrl("quotes") +
-          `/${selectedSymbol}?timeframe=${chartTimeframe}`;
+          `${getApiUrl("quotes").replace(/\/+$/, "")}/${selectedSymbol}?timeframe=${chartTimeframe}`;
         const res = await fetch(url);
         if (!res.ok) throw new Error("Quote fetch failed");
         const json = await res.json();
         const bars = json.bars || json.data || json || [];
-        if (bars.length === 0) return;
+        if (bars.length === 0) {
+          setChartError(true);
+          return;
+        }
         const rawData = bars.map((b) => {
           const t = b.timestamp ?? b.t ?? b.time;
           const ts = t != null ? Math.floor(new Date(t).getTime() / 1000) : NaN;
@@ -570,7 +572,10 @@ export default function SignalIntelligenceV3() {
             data[data.length - 1] = d;
           }
         }
-        if (data.length === 0) return;
+        if (data.length === 0) {
+          setChartError(true);
+          return;
+        }
         const volData = data.map((d) => ({
           time: d.time,
           value: d.volume,
@@ -1180,7 +1185,7 @@ export default function SignalIntelligenceV3() {
               />
               {chartError && (
                 <div className="absolute inset-0 flex items-center justify-center bg-[#0B0E14]/80">
-                  <span className="font-mono text-[10px] text-gray-500">No chart data available</span>
+                  <span className="font-mono text-[10px] text-gray-500">No historical data available for {selectedSymbol}</span>
                 </div>
               )}
             </div>

--- a/frontend-v2/src/pages/agent-tabs/AgentRegistryTab.jsx
+++ b/frontend-v2/src/pages/agent-tabs/AgentRegistryTab.jsx
@@ -7,7 +7,7 @@ import {
   CheckCircle, XCircle, AlertTriangle, ChevronDown, Settings,
 } from "lucide-react";
 import { toast } from "react-toastify";
-import { getApiUrl, getAuthHeaders } from "../../config/api";
+import { getApiUrl, getAuthHeaders, extractApiError } from "../../config/api";
 import { postAgentOverrideStatus, postAgentOverrideWeight } from "../../hooks/useApi";
 
 // ── Agent lifecycle API helpers ──────────────────────────────
@@ -16,21 +16,21 @@ const agentApi = {
     const res = await fetch(getApiUrl("agents") + `/${agentId}/start`, {
       method: "POST", headers: { ...getAuthHeaders() },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
     return res.json();
   },
   async stop(agentId) {
     const res = await fetch(getApiUrl("agents") + `/${agentId}/stop`, {
       method: "POST", headers: { ...getAuthHeaders() },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
     return res.json();
   },
   async restart(agentId) {
     const res = await fetch(getApiUrl("agents") + `/${agentId}/restart`, {
       method: "POST", headers: { ...getAuthHeaders() },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
     return res.json();
   },
   async updateConfig(agentId, config) {
@@ -39,28 +39,28 @@ const agentApi = {
       headers: { "Content-Type": "application/json", ...getAuthHeaders() },
       body: JSON.stringify(config),
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
     return res.json();
   },
   async batchStart() {
     const res = await fetch(getApiUrl("agents") + "/batch/start", {
       method: "POST", headers: { ...getAuthHeaders() },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
     return res.json();
   },
   async batchStop() {
     const res = await fetch(getApiUrl("agents") + "/batch/stop", {
       method: "POST", headers: { ...getAuthHeaders() },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
     return res.json();
   },
   async batchRestart() {
     const res = await fetch(getApiUrl("agents") + "/batch/restart", {
       method: "POST", headers: { ...getAuthHeaders() },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
     return res.json();
   },
 };

--- a/frontend-v2/src/pages/agent-tabs/SwarmOverviewTab.jsx
+++ b/frontend-v2/src/pages/agent-tabs/SwarmOverviewTab.jsx
@@ -14,7 +14,8 @@ import Card from "../../components/ui/Card";
 import { useApi, useEloLeaderboard, useHitlBuffer } from "../../hooks/useApi";
 import ws from "../../services/websocket";
 import { toast } from "react-toastify";
-import { getApiUrl, getAuthHeaders } from "../../config/api";
+import { getApiUrl, getAuthHeaders, extractApiError } from "../../config/api";
+import ConfirmDialog from "../../components/ui/ConfirmDialog";
 
 const HEALTH_COLORS = {
   healthy: "bg-emerald-500 shadow-emerald-500/50",
@@ -354,8 +355,8 @@ async function quickActionApi(path, method = "POST", body = undefined) {
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => ({}));
-    throw new Error(detail?.detail || detail?.message || `HTTP ${res.status}`);
+    const errMsg = await extractApiError(res);
+    throw new Error(errMsg);
   }
   return res.json();
 }
@@ -383,8 +384,8 @@ async function batchAgentAction(action) {
       if (failed > 0 && ok === 0) throw new Error(`All ${failed} agents failed`);
       return { ok: true, results: results.map((r, i) => ({ agent_id: i + 1, status: r.status === "fulfilled" ? "success" : "failed" })) };
     }
-    const detail = await res.json().catch(() => ({}));
-    throw new Error(detail?.detail || `HTTP ${res.status}`);
+    const errMsg = await extractApiError(res);
+    throw new Error(errMsg);
   } catch (e) {
     if (e.message?.includes("agents failed")) throw e;
     throw new Error(e?.message || "network error");
@@ -402,8 +403,8 @@ async function emergencyStopApi() {
     });
     clearTimeout(timeout);
     if (!res.ok) {
-      const detail = await res.json().catch(() => ({}));
-      throw new Error(detail?.detail || `HTTP ${res.status}`);
+      const errMsg = await extractApiError(res);
+      throw new Error(errMsg);
     }
     return res.json();
   } catch (e) {
@@ -414,30 +415,30 @@ async function emergencyStopApi() {
 }
 
 async function runConferenceApi() {
-  // Try POST to trigger conference, fall back to GET data display
-  const res = await fetch(getApiUrl("agents") + "/conference", {
-    method: "POST",
-    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
-    body: JSON.stringify({ action: "start" }),
-  });
-  if (res.ok) return res.json();
-  // POST may return 405 (Method Not Allowed) — that's expected if no POST handler
-  if (res.status === 405) {
-    // Fall back to GET to show current conference data
-    const getRes = await fetch(getApiUrl("conference"), { headers: getAuthHeaders() });
-    if (getRes.ok) {
-      const data = await getRes.json();
-      const hasData = data?.last_conference || data?.current || data?.total_conferences > 0;
-      if (hasData) return { ...data, _info: "Showing latest conference result (no POST trigger available)" };
-      throw new Error("No conference data available — council has not run yet");
-    }
+  // Try council/evaluate endpoint first (correct POST endpoint for triggering evaluation)
+  try {
+    const res = await fetch(getApiUrl("councilEvaluate"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+      body: JSON.stringify({}),
+    });
+    if (res.ok) return res.json();
+  } catch {}
+
+  // Fall back to GET conference data (agents/conference is GET-only)
+  const getRes = await fetch(getApiUrl("conference"), { headers: getAuthHeaders() });
+  if (getRes.ok) {
+    const data = await getRes.json();
+    const hasData = data?.last_conference || data?.current || data?.total_conferences > 0;
+    if (hasData) return { ...data, _info: "Showing latest conference result (trigger endpoint not available)" };
+    throw new Error("No conference data yet — council hasn't run. Signals must pass threshold (80) first.");
   }
-  const detail = await res.json().catch(() => ({}));
-  throw new Error(detail?.detail || `HTTP ${res.status}`);
+  throw new Error("Conference endpoint unavailable");
 }
 
 function QuickActions({ onRefetch }) {
   const [loading, setLoading] = useState(null);
+  const [confirmAction, setConfirmAction] = useState(null); // { label, title, description, confirmText, variant, fn }
   const run = async (label, fn) => {
     setLoading(label);
     toast.info(`${label}...`);
@@ -457,14 +458,40 @@ function QuickActions({ onRefetch }) {
     }
   };
   const actions = [
-    { label: "Restart All",    color: "bg-[#3b82f6] text-white border-[#3b82f6]", fn: () => batchAgentAction("restart") },
-    { label: "Stop All",       color: "bg-[#ef4444] text-white border-[#ef4444]", fn: () => batchAgentAction("stop") },
-    { label: "Spawn Team",     color: "bg-[#10b981] text-white border-[#10b981]", fn: () => batchAgentAction("start") },
-    { label: "Run Conference",  color: "bg-[#8b5cf6] text-white border-[#8b5cf6]", fn: runConferenceApi },
-    { label: "Emergency Kill",  color: "bg-[#ef4444] text-white border-[#ef4444]", fn: () => {
-      if (!window.confirm("⚠️ Emergency Kill: Cancel all orders and close all positions?")) throw new Error("Cancelled by user");
-      return emergencyStopApi();
+    { label: "Restart All",    loadingLabel: "Restarting...", color: "bg-[#3b82f6] text-white border-[#3b82f6]",
+      dangerous: true,
+      confirmTitle: "Restart All Agents",
+      confirmDesc: "Restart ALL agents? Running processes will be interrupted.",
+      confirmText: "Restart All",
+      confirmVariant: "warning",
+      fn: () => batchAgentAction("restart"),
+    },
+    { label: "Stop All",       loadingLabel: "Stopping...", color: "bg-[#ef4444] text-white border-[#ef4444]",
+      dangerous: true,
+      confirmTitle: "Stop All Agents",
+      confirmDesc: "Stop ALL agents? This will halt all autonomous trading.",
+      confirmText: "Stop All",
+      confirmVariant: "danger",
+      fn: () => batchAgentAction("stop"),
+    },
+    { label: "Spawn Team",     loadingLabel: "Spawning...", color: "bg-[#10b981] text-white border-[#10b981]", fn: async () => {
+      const res = await fetch(getApiUrl("agents/swarm/spawn"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) { const errMsg = await extractApiError(res); throw new Error(errMsg); }
+      return res.json();
     }},
+    { label: "Run Conference",  loadingLabel: "Running...", color: "bg-[#8b5cf6] text-white border-[#8b5cf6]", fn: runConferenceApi },
+    { label: "Emergency Kill",  loadingLabel: "Killing...", color: "bg-[#ef4444] text-white border-[#ef4444]",
+      dangerous: true,
+      confirmTitle: "Emergency Kill",
+      confirmDesc: "This will immediately cancel all orders and close all positions. Are you sure?",
+      confirmText: "Emergency Kill",
+      confirmVariant: "danger",
+      fn: () => emergencyStopApi(),
+    },
   ];
   return (
     <div className="bg-[#111827] border border-[#1e293b] rounded-md p-3">
@@ -474,13 +501,32 @@ function QuickActions({ onRefetch }) {
           <button
             key={a.label}
             disabled={loading != null}
-            onClick={() => run(a.label, a.fn)}
+            onClick={() => {
+              if (a.dangerous) {
+                setConfirmAction(a);
+              } else {
+                run(a.label, a.fn);
+              }
+            }}
             className={`px-2.5 py-1 text-[10px] font-bold rounded border ${a.color} hover:opacity-90 transition-opacity disabled:opacity-50`}
           >
-            {loading === a.label ? "…" : a.label}
+            {loading === a.label ? (a.loadingLabel || a.label + "...") : a.label}
           </button>
         ))}
       </div>
+      <ConfirmDialog
+        open={confirmAction != null}
+        onConfirm={() => {
+          const action = confirmAction;
+          setConfirmAction(null);
+          if (action) run(action.label, action.fn);
+        }}
+        onCancel={() => setConfirmAction(null)}
+        title={confirmAction?.confirmTitle ?? "Are you sure?"}
+        description={confirmAction?.confirmDesc ?? ""}
+        confirmText={confirmAction?.confirmText ?? "Confirm"}
+        variant={confirmAction?.confirmVariant ?? "danger"}
+      />
     </div>
   );
 }

--- a/frontend-v2/src/services/websocket.js
+++ b/frontend-v2/src/services/websocket.js
@@ -195,6 +195,14 @@ class AppWebSocket {
     return this.ws?.readyState === WebSocket.OPEN;
   }
 
+  /**
+   * Return the current connection state string.
+   * Possible values: "disconnected" | "connecting" | "connected" | "reconnecting"
+   */
+  getState() {
+    return this.state;
+  }
+
   // --- Kelly channel subscriptions ---
   subscribeKelly(callback) {
     return this.on("kelly", callback);


### PR DESCRIPTION
## Summary
- **WebSocket root cause fix**: WS URL now connects to backend (`ws://localhost:8001`) instead of Vite dev server — eliminates all WS connection errors and error spam
- **Auth error handling**: `extractApiError` shows clear "configure API_AUTH_TOKEN" messages instead of silent 403 failures
- **Agent button fixes**: Correct endpoints for Spawn Team, Run Conference, batch start/stop/restart; all with loading states + toast feedback
- **CSV export**: Generates proper CSV with 15 columns, triggers browser download, shows toast with count
- **Timeframe buttons**: Now re-fetch signals immediately with correct URL and timeframe parameter
- **Confirmation dialogs**: Flatten All, Emergency Stop, and Kill All require confirmation before executing
- **Polling optimization**: Tiered intervals (5s/15s/30-60s), request deduplication (2s cache), tab visibility pause
- **12 files changed**, 506 insertions, 146 deletions — build passes clean

## Test plan
- [ ] Verify WS connects without error spam (check browser console)
- [ ] Click "Restart All" on Agent Command Center → should show loading + toast
- [ ] Click "Export CSV" on Dashboard → should download .csv file + toast
- [ ] Click timeframe buttons (1m, 5m, 1h) → table should re-fetch with loading indicator
- [ ] Click "Flatten All" → confirmation dialog should appear before executing
- [ ] Click "Emergency Stop" → confirmation dialog with red button
- [ ] Open DevTools Network → verify polling intervals are staggered (not all 5s)
- [ ] Switch to another tab for 30s, switch back → verify polling resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)