### PR TITLE
Wake the brain: enable LLM pipeline + fix signal flow (#55-65)

### DIFF
--- a/backend/app/api/v1/flywheel.py
+++ b/backend/app/api/v1/flywheel.py
@@ -81,11 +81,28 @@ async def get_flywheel():
     data = _get_flywheel_data()
     acc30 = data.get("accuracy30d", 0.0)
     acc90 = data.get("accuracy90d", 0.0)
+
+    # Pull live resolved count from outcome_resolver as fallback
+    resolved = data.get("resolvedSignals", 0)
+    try:
+        from app.modules.ml_engine.outcome_resolver import get_flywheel_metrics
+        metrics = get_flywheel_metrics()
+        live_count = metrics.get("resolved_count", 0)
+        if live_count > resolved:
+            resolved = live_count
+            # Also pull live accuracy if flywheel_data hasn't been synced yet
+            if metrics.get("accuracy_30d") is not None and acc30 == 0.0:
+                acc30 = float(metrics["accuracy_30d"])
+            if metrics.get("accuracy_90d") is not None and acc90 == 0.0:
+                acc90 = float(metrics["accuracy_90d"])
+    except Exception:
+        pass
+
     return {
         "accuracy30d": acc30,
         "accuracy90d": acc90,
         "accuracy": round(acc30 * 100, 1),
-        "resolvedSignals": data.get("resolvedSignals", 0),
+        "resolvedSignals": resolved,
         "pendingResolution": data.get("pendingResolution", 0),
         "history": data.get("history", [])[-90:],
     }
@@ -168,6 +185,23 @@ async def get_flywheel_performance():
 async def get_flywheel_signals_staged():
     """Staged signals for flywheel. Stub."""
     return {"flywheel": {"signals": [], "staged": 0}}
+
+
+@router.post("/resolve-signals", dependencies=[Depends(require_auth)])
+async def resolve_historical_signals_endpoint():
+    """Manually trigger retroactive resolution of turbo_scanner signals.
+
+    Checks past signals' predicted directions against current prices and
+    records outcomes to the flywheel, bootstrapping the feedback loop
+    without requiring actual trades.
+    """
+    try:
+        from app.services.outcome_tracker import resolve_historical_signals
+        result = await resolve_historical_signals()
+        return {"status": "completed", **result}
+    except Exception as e:
+        logger.error("resolve_historical_signals failed: %s", e)
+        return {"status": "error", "error": str(e)}
 
 
 @router.get("/models")

--- a/backend/app/api/v1/openclaw.py
+++ b/backend/app/api/v1/openclaw.py
@@ -233,8 +233,36 @@ async def get_regime():
     """
     Return current market regime status.
     Response: {state: GREEN|YELLOW|RED, vix, hmm_confidence, hurst, macro_context}
+
+    Falls back to price-action regime from SPY OHLCV when bridge data
+    is unavailable (Issue #60).
     """
-    return await openclaw_bridge.get_regime()
+    result = await openclaw_bridge.get_regime()
+
+    # If bridge returns UNKNOWN, try price-action fallback from DuckDB SPY data
+    if result.get("state") in ("UNKNOWN", None):
+        try:
+            from app.council.regime.price_action_regime import (
+                get_price_action_regime,
+                _PA_TO_OPENCLAW,
+            )
+            pa = await get_price_action_regime()
+            pa_regime = pa.get("regime", "UNKNOWN")
+            if pa_regime != "UNKNOWN":
+                openclaw_color = _PA_TO_OPENCLAW.get(pa_regime, "YELLOW")
+                result["state"] = openclaw_color
+                result["price_action_regime"] = pa_regime
+                result["hmm_confidence"] = pa.get("confidence", 0.0)
+                result["price_action_details"] = pa.get("details", {})
+                result["regime_source"] = "price_action_fallback"
+                logger.info(
+                    "[OPENCLAW] Regime endpoint using price-action fallback: %s (%s)",
+                    pa_regime, openclaw_color,
+                )
+        except Exception as e:
+            logger.debug("[OPENCLAW] Price-action fallback failed in regime endpoint: %s", e)
+
+    return result
 
 
 @router.get("/top")

--- a/backend/app/api/v1/signals.py
+++ b/backend/app/api/v1/signals.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from datetime import date
 from pathlib import Path
+from typing import Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from app.core.security import require_auth
@@ -16,6 +17,101 @@ from app.services.kelly_position_sizer import KellyPositionSizer
 _kelly_sizer = KellyPositionSizer(max_allocation=0.10)
 
 logger = logging.getLogger(__name__)
+
+# ── ATR multipliers by pattern type ──────────────────────────────────────────
+# RSI extreme patterns: tighter stops (mean reversion, quick snapback)
+# Momentum/breakout: wider stops (trend following, needs room to breathe)
+_PATTERN_ATR_MULTIPLIERS: Dict[str, Dict[str, float]] = {
+    "rsi_extreme":      {"stop": 1.5, "target": 2.5},
+    "rsi_oversold":     {"stop": 1.5, "target": 2.5},
+    "rsi_overbought":   {"stop": 1.5, "target": 2.5},
+    "mean_reversion":   {"stop": 1.5, "target": 2.5},
+    "momentum":         {"stop": 2.5, "target": 3.5},
+    "breakout":         {"stop": 2.5, "target": 3.5},
+    "volume_breakout":  {"stop": 2.5, "target": 3.5},
+    "trend_following":  {"stop": 2.5, "target": 3.5},
+}
+_DEFAULT_ATR_MULT = {"stop": 2.0, "target": 3.0}
+
+
+def _fetch_atr_for_symbol(symbol: str) -> Optional[float]:
+    """Fetch latest ATR-14 from DuckDB technical_indicators table.
+
+    This is a SYNCHRONOUS function — must be called via asyncio.to_thread()
+    from async contexts to avoid blocking the event loop.
+    """
+    try:
+        from app.data.duckdb_storage import duckdb_store
+        cursor = duckdb_store.get_thread_cursor()
+        row = cursor.execute(
+            "SELECT atr_14 FROM technical_indicators "
+            "WHERE symbol = ? ORDER BY date DESC LIMIT 1",
+            [symbol.upper()],
+        ).fetchone()
+        if row and row[0] is not None and row[0] > 0:
+            return float(row[0])
+    except Exception as e:
+        logger.debug("ATR lookup failed for %s: %s", symbol, e)
+    return None
+
+
+def _fetch_atr_batch(symbols: list[str]) -> Dict[str, float]:
+    """Fetch latest ATR-14 for multiple symbols in a single query.
+
+    SYNCHRONOUS — call via asyncio.to_thread().
+    """
+    atr_map: Dict[str, float] = {}
+    if not symbols:
+        return atr_map
+    try:
+        from app.data.duckdb_storage import duckdb_store
+        cursor = duckdb_store.get_thread_cursor()
+        placeholders = ", ".join(["?"] * len(symbols))
+        rows = cursor.execute(
+            f"SELECT symbol, atr_14 FROM ("
+            f"  SELECT symbol, atr_14, "
+            f"    ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY date DESC) AS rn "
+            f"  FROM technical_indicators "
+            f"  WHERE symbol IN ({placeholders})"
+            f") WHERE rn = 1",
+            [s.upper() for s in symbols],
+        ).fetchall()
+        for row in rows:
+            if row[1] is not None and row[1] > 0:
+                atr_map[row[0]] = float(row[1])
+    except Exception as e:
+        logger.debug("Batch ATR lookup failed: %s", e)
+    return atr_map
+
+
+def _compute_atr_levels(
+    entry: float,
+    atr: float,
+    direction: str,
+    pattern: str = "",
+) -> Dict[str, float]:
+    """Compute entry/target/stop using ATR and pattern-specific multipliers."""
+    pattern_lower = pattern.lower().strip()
+    mult = _DEFAULT_ATR_MULT
+    for key, m in _PATTERN_ATR_MULTIPLIERS.items():
+        if key in pattern_lower:
+            mult = m
+            break
+
+    if direction == "LONG":
+        stop = round(entry - atr * mult["stop"], 2)
+        target = round(entry + atr * mult["target"], 2)
+    else:
+        stop = round(entry + atr * mult["stop"], 2)
+        target = round(entry - atr * mult["target"], 2)
+
+    risk = abs(entry - stop)
+    reward = abs(target - entry)
+    r_mult = round(reward / risk, 1) if risk > 0 else 1.5
+
+    return {"target": target, "stop": stop, "r_multiple": r_mult}
+
+
 router = APIRouter()
 
 FEATURE_COLS = ["return_1d", "ma_10_dist", "ma_20_dist", "vol_20", "vol_rel"]
@@ -112,6 +208,10 @@ async def get_signals(as_of: date | None = None):
             if sym not in seen or ss.get("score", 0) > seen[sym].get("score", 0):
                 seen[sym] = ss
 
+        # Batch-fetch ATR for all symbols (single DuckDB query in thread)
+        all_syms = list(seen.keys())
+        atr_map = await asyncio.to_thread(_fetch_atr_batch, all_syms)
+
         for sym, ss in seen.items():
             raw_score = ss.get("score", 0)
             score_100 = round(raw_score * 100) if raw_score <= 1.0 else round(raw_score)
@@ -120,11 +220,28 @@ async def get_signals(as_of: date | None = None):
             )
             price = ss.get("data", {}).get("close", ss.get("data", {}).get("price", 0))
             entry = round(price, 2) if price else 0
-            target = round(entry * (1.03 if direction == "LONG" else 0.97), 2) if entry else 0
-            stop = round(entry * (0.98 if direction == "LONG" else 1.02), 2) if entry else 0
-            r_mult = round((abs(target - entry) / abs(entry - stop)), 1) if entry and stop and entry != stop else 1.5
+            pattern = ss.get("signal_type", "")
+
+            # ATR-based entry/target/stop (fall back to fixed % if no ATR)
+            atr_val = atr_map.get(sym)
+            if entry and atr_val:
+                levels = _compute_atr_levels(entry, atr_val, direction, pattern)
+                target = levels["target"]
+                stop = levels["stop"]
+                r_mult = levels["r_multiple"]
+                # Compute actual avg_win / avg_loss from the ATR levels
+                avg_win_pct = abs(target - entry) / entry if entry else 0.035
+                avg_loss_pct = abs(entry - stop) / entry if entry else 0.015
+            else:
+                # Fallback: fixed percentage when no ATR data available
+                target = round(entry * (1.03 if direction == "LONG" else 0.97), 2) if entry else 0
+                stop = round(entry * (0.98 if direction == "LONG" else 1.02), 2) if entry else 0
+                r_mult = round((abs(target - entry) / abs(entry - stop)), 1) if entry and stop and entry != stop else 1.5
+                avg_win_pct = 0.035
+                avg_loss_pct = 0.015
+
             kelly = _kelly_sizer.calculate(
-                win_rate=max(0.5, score_100 / 100), avg_win_pct=0.035, avg_loss_pct=0.015,
+                win_rate=max(0.5, score_100 / 100), avg_win_pct=avg_win_pct, avg_loss_pct=avg_loss_pct,
             )
             dashboard_signals.append({
                 "symbol": sym,

--- a/backend/app/council/regime/price_action_regime.py
+++ b/backend/app/council/regime/price_action_regime.py
@@ -1,0 +1,282 @@
+"""Price-Action Regime Fallback — classifies market regime using SPY OHLCV data.
+
+When the Bayesian engine lacks VIX/macro inputs and the HMM model hasn't been
+trained, this module provides a simple but effective regime classification
+using only SPY daily bars from DuckDB.
+
+Metrics used:
+    - Trend: price vs 20 SMA and 50 SMA
+    - Volatility: ATR percentile over lookback window
+    - Drawdown: % from rolling 252-day high
+    - Breadth proxy: % of recent bars that closed up
+
+Returns one of: BULLISH, BEARISH, SIDEWAYS, CRISIS, UNKNOWN
+
+Issue #60: Market regime stuck at UNKNOWN — this is the fallback.
+"""
+import asyncio
+import logging
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Regime labels compatible with the rest of the system
+REGIMES = ("BULLISH", "BEARISH", "SIDEWAYS", "CRISIS", "UNKNOWN")
+
+# Map price-action regimes to Bayesian-style state names for beliefs dict
+_PA_TO_BAYESIAN = {
+    "BULLISH": "trending_bull",
+    "BEARISH": "trending_bear",
+    "SIDEWAYS": "mean_revert",
+    "CRISIS": "high_vol_crisis",
+    "UNKNOWN": "transition",
+}
+
+# Map price-action regimes to OpenClaw color codes
+_PA_TO_OPENCLAW = {
+    "BULLISH": "GREEN",
+    "BEARISH": "RED",
+    "SIDEWAYS": "YELLOW",
+    "CRISIS": "RED",
+    "UNKNOWN": "YELLOW",
+}
+
+
+def _fetch_spy_bars_from_duckdb(limit: int = 260) -> Optional[list]:
+    """Fetch recent SPY daily bars from DuckDB (synchronous — call via to_thread).
+
+    Returns list of dicts with keys: date, open, high, low, close, volume.
+    Returns None if data is unavailable.
+    """
+    try:
+        from app.data.duckdb_storage import duckdb_store
+        cur = duckdb_store.get_thread_cursor()
+        try:
+            rows = cur.execute(
+                """
+                SELECT date, open, high, low, close, volume
+                FROM daily_ohlcv
+                WHERE symbol = 'SPY'
+                ORDER BY date DESC
+                LIMIT ?
+                """,
+                [limit],
+            ).fetchall()
+        finally:
+            cur.close()
+
+        if not rows:
+            return None
+
+        # Reverse to chronological order (oldest first)
+        rows = rows[::-1]
+        return [
+            {
+                "date": r[0],
+                "open": float(r[1]) if r[1] is not None else 0.0,
+                "high": float(r[2]) if r[2] is not None else 0.0,
+                "low": float(r[3]) if r[3] is not None else 0.0,
+                "close": float(r[4]) if r[4] is not None else 0.0,
+                "volume": int(r[5]) if r[5] is not None else 0,
+            }
+            for r in rows
+        ]
+    except Exception as e:
+        logger.error("price_action_regime: DuckDB query failed: %s", e)
+        return None
+
+
+def classify_regime_from_price_action(
+    bars: list,
+) -> Tuple[str, float, Dict]:
+    """Classify market regime from SPY OHLCV bars.
+
+    Args:
+        bars: List of dicts with keys: open, high, low, close, volume.
+              Must be in chronological order (oldest first).
+              Needs at least 50 bars for reliable classification.
+
+    Returns:
+        Tuple of (regime_label, confidence, details_dict)
+    """
+    if not bars or len(bars) < 20:
+        return "UNKNOWN", 0.0, {"error": "insufficient data", "bar_count": len(bars) if bars else 0}
+
+    closes = [b["close"] for b in bars]
+    highs = [b["high"] for b in bars]
+    lows = [b["low"] for b in bars]
+    n = len(closes)
+
+    # ── 1. Trend: price vs 20 SMA and 50 SMA ──────────────────────────
+    sma_20 = sum(closes[-20:]) / 20
+    sma_50 = sum(closes[-min(50, n):]) / min(50, n)
+    current_price = closes[-1]
+
+    above_sma20 = current_price > sma_20
+    above_sma50 = current_price > sma_50
+    sma20_above_sma50 = sma_20 > sma_50
+
+    # Trend score: -1 (strong bearish) to +1 (strong bullish)
+    trend_score = 0.0
+    if above_sma20:
+        trend_score += 0.33
+    else:
+        trend_score -= 0.33
+    if above_sma50:
+        trend_score += 0.33
+    else:
+        trend_score -= 0.33
+    if sma20_above_sma50:
+        trend_score += 0.34
+    else:
+        trend_score -= 0.34
+
+    # ── 2. Volatility: ATR percentile ──────────────────────────────────
+    # Calculate 14-period ATR for the full history
+    atrs = []
+    for i in range(1, n):
+        tr = max(
+            highs[i] - lows[i],
+            abs(highs[i] - closes[i - 1]),
+            abs(lows[i] - closes[i - 1]),
+        )
+        atrs.append(tr)
+
+    if len(atrs) >= 14:
+        # Current ATR (14-period average)
+        current_atr = sum(atrs[-14:]) / 14
+        # ATR as percentage of price
+        atr_pct = (current_atr / current_price) * 100 if current_price > 0 else 0
+
+        # Percentile rank of current ATR vs all ATRs
+        atr_pcts = [(a / closes[i + 1]) * 100 if closes[i + 1] > 0 else 0 for i, a in enumerate(atrs)]
+        below_count = sum(1 for a in atr_pcts if a <= atr_pct)
+        atr_percentile = below_count / len(atr_pcts) if atr_pcts else 0.5
+    else:
+        atr_pct = 0.0
+        atr_percentile = 0.5
+
+    # ── 3. Drawdown from rolling high ──────────────────────────────────
+    lookback_252 = min(252, n)
+    rolling_high = max(highs[-lookback_252:])
+    drawdown_pct = ((current_price - rolling_high) / rolling_high) * 100 if rolling_high > 0 else 0
+
+    # ── 4. Breadth proxy: % of last 20 bars that closed up ────────────
+    recent_n = min(20, n - 1)
+    up_bars = sum(1 for i in range(n - recent_n, n) if closes[i] > closes[i - 1])
+    up_ratio = up_bars / recent_n if recent_n > 0 else 0.5
+
+    # ── Classification logic ───────────────────────────────────────────
+    regime = "SIDEWAYS"
+    confidence = 0.5
+
+    # CRISIS: deep drawdown + high volatility
+    if drawdown_pct < -10 and atr_percentile > 0.80:
+        regime = "CRISIS"
+        confidence = min(0.95, 0.6 + abs(drawdown_pct) / 100 + (atr_percentile - 0.8))
+    # BEARISH: negative trend + drawdown
+    elif trend_score < -0.3 and drawdown_pct < -5:
+        regime = "BEARISH"
+        confidence = min(0.90, 0.5 + abs(trend_score) * 0.3 + abs(drawdown_pct) / 50)
+    # BULLISH: positive trend + limited drawdown + decent breadth
+    elif trend_score > 0.3 and drawdown_pct > -5 and up_ratio > 0.45:
+        regime = "BULLISH"
+        confidence = min(0.90, 0.5 + trend_score * 0.3 + up_ratio * 0.2)
+    # SIDEWAYS: weak trend, moderate everything
+    else:
+        regime = "SIDEWAYS"
+        # Confidence is higher when metrics are truly mixed
+        confidence = 0.5 + (1.0 - abs(trend_score)) * 0.2
+
+    confidence = round(max(0.1, min(confidence, 0.95)), 4)
+
+    details = {
+        "source": "price_action_fallback",
+        "bar_count": n,
+        "current_price": round(current_price, 2),
+        "sma_20": round(sma_20, 2),
+        "sma_50": round(sma_50, 2),
+        "trend_score": round(trend_score, 4),
+        "atr_pct": round(atr_pct, 4),
+        "atr_percentile": round(atr_percentile, 4),
+        "drawdown_pct": round(drawdown_pct, 2),
+        "up_ratio_20": round(up_ratio, 4),
+        "rolling_high_252": round(rolling_high, 2),
+    }
+
+    return regime, confidence, details
+
+
+async def get_price_action_regime() -> Dict:
+    """Async entry point: fetch SPY bars from DuckDB and classify regime.
+
+    Uses asyncio.to_thread for the DuckDB query to avoid blocking the event loop.
+
+    Returns:
+        Dict with regime, confidence, beliefs, details, and source info.
+    """
+    try:
+        bars = await asyncio.to_thread(_fetch_spy_bars_from_duckdb, 260)
+        if not bars or len(bars) < 20:
+            logger.warning(
+                "price_action_regime: insufficient SPY bars (%d) — need at least 20",
+                len(bars) if bars else 0,
+            )
+            return {
+                "regime": "UNKNOWN",
+                "confidence": 0.0,
+                "beliefs": {},
+                "details": {"error": "insufficient SPY data in DuckDB"},
+                "source": "price_action_fallback",
+            }
+
+        regime, confidence, details = classify_regime_from_price_action(bars)
+
+        # Build beliefs dict compatible with BayesianRegime format
+        beliefs = {
+            "trending_bull": 0.0,
+            "trending_bear": 0.0,
+            "mean_revert": 0.0,
+            "high_vol_crisis": 0.0,
+            "low_vol_grind": 0.0,
+            "transition": 0.0,
+        }
+        # Assign confidence to the matching Bayesian state
+        bayesian_state = _PA_TO_BAYESIAN.get(regime, "transition")
+        beliefs[bayesian_state] = confidence
+        # Distribute remaining probability
+        remaining = 1.0 - confidence
+        other_states = [s for s in beliefs if s != bayesian_state]
+        for s in other_states:
+            beliefs[s] = round(remaining / len(other_states), 4)
+
+        openclaw_color = _PA_TO_OPENCLAW.get(regime, "YELLOW")
+
+        logger.info(
+            "price_action_regime: %s (conf=%.1f%%) | SPY=%.2f | dd=%.1f%% | trend=%.2f | atr_pctl=%.0f%%",
+            regime,
+            confidence * 100,
+            details.get("current_price", 0),
+            details.get("drawdown_pct", 0),
+            details.get("trend_score", 0),
+            details.get("atr_percentile", 0) * 100,
+        )
+
+        return {
+            "regime": regime,
+            "confidence": confidence,
+            "beliefs": beliefs,
+            "details": details,
+            "source": "price_action_fallback",
+            "openclaw_color": openclaw_color,
+        }
+
+    except Exception as e:
+        logger.error("price_action_regime: failed: %s", e)
+        return {
+            "regime": "UNKNOWN",
+            "confidence": 0.0,
+            "beliefs": {},
+            "details": {"error": str(e)},
+            "source": "price_action_fallback",
+        }

--- a/backend/app/council/regime_publisher.py
+++ b/backend/app/council/regime_publisher.py
@@ -100,7 +100,7 @@ class RegimePublisher:
         except Exception:
             pass
 
-        # Fallback: read from DuckDB if Bayesian engine hasn't been updated
+        # Fallback 1: read from DuckDB if Bayesian engine hasn't been updated
         if regime == "UNKNOWN" or not beliefs:
             try:
                 def _fetch_regime():
@@ -118,6 +118,32 @@ class RegimePublisher:
                     source = "duckdb_last_decision"
             except Exception:
                 pass
+
+        # Fallback 2: price-action regime from SPY OHLCV in DuckDB (Issue #60)
+        if regime == "UNKNOWN" or not beliefs:
+            try:
+                from app.council.regime.price_action_regime import get_price_action_regime
+                pa_result = await get_price_action_regime()
+                pa_regime = pa_result.get("regime", "UNKNOWN")
+                if pa_regime != "UNKNOWN":
+                    regime = pa_regime
+                    probability = pa_result.get("confidence", 0.0)
+                    beliefs = pa_result.get("beliefs", {})
+                    source = "price_action_fallback"
+                    # Derive entropy from confidence (higher confidence = lower entropy)
+                    import math
+                    if probability > 0 and probability < 1:
+                        entropy = -(probability * math.log(probability) + (1 - probability) * math.log(1 - probability))
+                    else:
+                        entropy = 0.0
+                    # Conservative position sizing for fallback
+                    position_modifier = round(0.5 + probability * 0.4, 3)
+                    logger.info(
+                        "RegimePublisher: using price-action fallback → %s (conf=%.0f%%)",
+                        regime, probability * 100,
+                    )
+            except Exception as e:
+                logger.debug("RegimePublisher: price-action fallback failed: %s", e)
 
         # Publish to MessageBus
         bus = get_message_bus()

--- a/backend/app/jobs/scheduler.py
+++ b/backend/app/jobs/scheduler.py
@@ -182,6 +182,21 @@ def _run_morning_briefing():
         log.exception("Scheduled morning_briefing failed: %s", e)
 
 
+def _run_historical_signal_resolution():
+    """Hourly: resolve past turbo_scanner signals against current prices to feed the flywheel."""
+    import asyncio
+    from app.services.outcome_tracker import resolve_historical_signals
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            asyncio.ensure_future(resolve_historical_signals())
+        else:
+            asyncio.run(resolve_historical_signals())
+        log.info("Scheduled historical_signal_resolution triggered")
+    except Exception as e:
+        log.exception("Scheduled historical_signal_resolution failed: %s", e)
+
+
 def start_scheduler() -> Optional[object]:
     """Start the APScheduler with flywheel jobs.
 
@@ -262,6 +277,15 @@ def start_scheduler() -> Optional[object]:
         CronTrigger(hour=9, minute=0, day_of_week="mon-fri", timezone="America/New_York"),
         id="morning_briefing",
         name="Morning Briefing (9 AM ET)",
+        replace_existing=True,
+    )
+
+    # Hourly weekdays — retroactive signal resolution to bootstrap flywheel
+    _scheduler.add_job(
+        _run_historical_signal_resolution,
+        CronTrigger(minute=30, day_of_week="mon-fri", timezone="UTC"),
+        id="historical_signal_resolution",
+        name="Historical Signal Resolution (hourly)",
         replace_existing=True,
     )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1004,6 +1004,39 @@ async def _start_event_driven_pipeline():
     else:
         log.info("\u26A0\uFE0F UnifiedProfitEngine skipped (LLM_ENABLED=false)")
 
+    # 22b. Direct bypass: when LLM/council is off, turbo_scanner signals scoring >=85
+    # can reach the executor directly for shadow/paper execution (issue #59).
+    # This ensures the system can still paper-trade without the full council.
+    if not _llm_enabled or not council_gate_enabled:
+        async def _turbo_direct_bypass(signal_data):
+            """Route high-scoring signals directly to OrderExecutor when council is offline."""
+            from app.core.score_semantics import coerce_signal_score_0_100, score_to_final_confidence_0_1
+            raw_score = signal_data.get("score", 0)
+            score_100 = coerce_signal_score_0_100(raw_score, context="turbo_direct_bypass")
+            source = signal_data.get("source", "")
+            # Only bypass for turbo_scanner signals with score >= 85
+            if source != "turbo_scanner" or score_100 < 85.0:
+                return
+            import time as _t
+            log.info(
+                "Direct bypass: turbo_scanner signal %s score=%.0f -> council.verdict",
+                signal_data.get("symbol", "?"), score_100,
+            )
+            await _message_bus.publish("council.verdict", {
+                "symbol": signal_data.get("symbol", ""),
+                "final_direction": signal_data.get("label", "long"),
+                "final_confidence": score_to_final_confidence_0_1(score_100, context="turbo_direct_bypass"),
+                "execution_ready": True,
+                "vetoed": False,
+                "votes": [],
+                "council_reasoning": f"Direct turbo_scanner bypass (score={score_100:.0f}, council offline)",
+                "signal_data": signal_data,
+                "price": signal_data.get("close", signal_data.get("price", 0)),
+                "timestamp": _t.time(),
+            })
+        await _message_bus.subscribe("signal.generated", _turbo_direct_bypass)
+        log.info("\u2705 Turbo direct bypass registered (score>=85 -> OrderExecutor when council offline)")
+
     # 23. PositionManager — automated exits (trailing stops, time exits, partial profits)
     # BUG FIX 3: Always start — uses Alpaca API for position management, no LLM dependency.
     from app.services.position_manager import get_position_manager

--- a/backend/app/services/order_executor.py
+++ b/backend/app/services/order_executor.py
@@ -203,11 +203,13 @@ class OrderExecutor:
         return self._trade_stats
 
     async def start(self) -> None:
-        """Subscribe to council.verdict and begin processing."""
+        """Subscribe to council.verdict and signal.unified, then begin processing."""
         self._running = True
         self._start_time = time.time()
         # Primary: listen to council-approved verdicts
         await self.message_bus.subscribe("council.verdict", self._on_council_verdict)
+        # Secondary: listen to UnifiedProfitEngine high-confidence scores (issue #59)
+        await self.message_bus.subscribe("signal.unified", self._on_unified_signal)
         mode = "AUTO-EXECUTE" if self.auto_execute else "SHADOW (dry-run)"
         logger.info(
             "OrderExecutor started in %s mode (council-controlled) -- "
@@ -223,12 +225,62 @@ class OrderExecutor:
         """Unsubscribe and stop processing."""
         self._running = False
         await self.message_bus.unsubscribe("council.verdict", self._on_council_verdict)
+        await self.message_bus.unsubscribe("signal.unified", self._on_unified_signal)
         logger.info(
             "OrderExecutor stopped -- %d signals received, %d executed, %d rejected",
             self._signals_received,
             self._signals_executed,
             self._signals_rejected,
         )
+
+    async def _on_unified_signal(self, unified_data: Dict[str, Any]) -> None:
+        """Process a signal.unified event from UnifiedProfitEngine.
+
+        Converts high-confidence unified scores (>=75) into council.verdict
+        format and routes them through the normal execution pipeline.
+        This closes the gap where signal.unified had no subscriber (issue #59).
+        """
+        if not self._running:
+            return
+
+        score = unified_data.get("unified_score", 0)
+        direction = unified_data.get("direction", "neutral")
+        confidence = unified_data.get("confidence", 0)
+        symbol = unified_data.get("symbol", "")
+
+        # Only route high-confidence unified signals (>=75 score)
+        if score < 75 or direction == "neutral" or not symbol:
+            return
+
+        logger.info(
+            "UnifiedProfitEngine signal accepted: %s score=%.1f dir=%s conf=%.3f brains=%d",
+            symbol, score, direction, confidence, unified_data.get("brains_active", 0),
+        )
+
+        # Convert to council.verdict format for the existing execution pipeline
+        verdict = {
+            "symbol": symbol,
+            "final_direction": "long" if direction == "bullish" else "short",
+            "final_confidence": max(confidence, score / 100.0),
+            "execution_ready": True,
+            "vetoed": False,
+            "votes": [],
+            "council_reasoning": (
+                f"UnifiedProfitEngine bypass — score={score:.1f}, "
+                f"{unified_data.get('brains_active', 0)} brains active, "
+                f"weights={unified_data.get('brain_scores', {})}"
+            ),
+            "signal_data": {
+                "symbol": symbol,
+                "score": score,
+                "source": "unified_profit_engine",
+                "brain_scores": unified_data.get("brain_scores", {}),
+            },
+            "price": unified_data.get("price", 0),
+            "timestamp": unified_data.get("timestamp", time.time()),
+        }
+
+        await self._on_council_verdict(verdict)
 
     # -- Main Council Verdict Handler --
     async def _on_council_verdict(self, verdict_data: Dict[str, Any]) -> None:

--- a/backend/app/services/outcome_tracker.py
+++ b/backend/app/services/outcome_tracker.py
@@ -601,6 +601,13 @@ class OutcomeTracker:
         except Exception as e:
             logger.debug("ML outcome resolver error: %s", e)
 
+        # Sync flywheel_data store so dashboard resolvedSignals updates in real-time
+        # (not just at the daily 18:00 UTC job)
+        try:
+            _sync_flywheel_data_from_resolver()
+        except Exception as e:
+            logger.debug("Flywheel data sync error: %s", e)
+
         # Publish event
         if self._bus:
             asyncio.create_task(self._bus.publish("outcome.resolved", pos.to_dict()))
@@ -748,6 +755,198 @@ class OutcomeTracker:
 
     def get_closed_positions(self, limit: int = 50) -> List[Dict[str, Any]]:
         return [p.to_dict() for p in self._closed[-limit:]]
+
+
+def _sync_flywheel_data_from_resolver() -> None:
+    """Sync outcome_resolver metrics into flywheel_data so the dashboard
+    resolvedSignals counter updates immediately (not just at the daily job)."""
+    from app.modules.ml_engine.outcome_resolver import get_flywheel_metrics
+    from app.services.database import db_service as _db
+
+    metrics = get_flywheel_metrics()
+    stored = _db.get_config("flywheel_data") or {}
+    acc_30 = metrics.get("accuracy_30d")
+    acc_90 = metrics.get("accuracy_90d")
+    stored["resolvedSignals"] = metrics.get("resolved_count", 0)
+    if acc_30 is not None:
+        stored["accuracy30d"] = float(acc_30)
+    if acc_90 is not None:
+        stored["accuracy90d"] = float(acc_90)
+    _db.set_config("flywheel_data", stored)
+
+
+async def resolve_historical_signals() -> Dict[str, Any]:
+    """Check past turbo_scanner signals against current prices to see if the
+    predicted direction was correct.  This bootstraps the flywheel without
+    needing actual trades.
+
+    Returns:
+        Summary dict with resolved/skipped/error counts.
+    """
+    from app.modules.ml_engine.outcome_resolver import record_outcome as ml_record, _get_store
+
+    result = {"resolved": 0, "skipped": 0, "errors": 0}
+
+    # 1. Gather recent signals from turbo_scanner history
+    try:
+        from app.services.turbo_scanner import get_turbo_scanner
+        scanner = get_turbo_scanner()
+        signals = scanner.get_signals(limit=200)  # last 200 signals
+    except Exception as e:
+        logger.warning("resolve_historical_signals: cannot get scanner signals: %s", e)
+        return {**result, "error": str(e)}
+
+    if not signals:
+        logger.info("resolve_historical_signals: no signals to resolve")
+        return result
+
+    # 2. Build set of already-resolved (symbol, signal_date) to avoid duplicates
+    try:
+        store = _get_store()
+        existing = {
+            (r.get("symbol", ""), r.get("signal_date", ""))
+            for r in (store.get("resolved") or [])
+        }
+    except Exception:
+        existing = set()
+
+    # 3. Filter signals that have a price and direction, and are old enough (>1h)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    candidates = []
+    for sig in signals:
+        direction = sig.get("direction", "unknown")
+        if direction == "unknown":
+            result["skipped"] += 1
+            continue
+        detected_at = sig.get("detected_at", "")
+        if not detected_at:
+            result["skipped"] += 1
+            continue
+        # Must be at least 1 hour old to give the prediction time to play out
+        try:
+            sig_dt = datetime.fromisoformat(detected_at.replace("Z", "+00:00"))
+            age_hours = (datetime.now(timezone.utc) - sig_dt).total_seconds() / 3600
+            if age_hours < 1:
+                result["skipped"] += 1
+                continue
+        except Exception:
+            result["skipped"] += 1
+            continue
+
+        sig_date = sig_dt.strftime("%Y-%m-%d")
+        symbol = sig.get("symbol", "").upper()
+        if (symbol, sig_date) in existing:
+            result["skipped"] += 1
+            continue
+
+        entry_price = 0.0
+        data = sig.get("data", {})
+        if isinstance(data, dict):
+            entry_price = float(data.get("close", 0) or data.get("price", 0) or 0)
+        if entry_price <= 0:
+            result["skipped"] += 1
+            continue
+
+        candidates.append({
+            "symbol": symbol,
+            "direction": direction,
+            "entry_price": entry_price,
+            "signal_date": sig_date,
+            "score": sig.get("score", 0.5),
+        })
+
+    if not candidates:
+        logger.info("resolve_historical_signals: no eligible candidates")
+        return result
+
+    # 4. Fetch current prices (DuckDB + Alpaca fallback) via asyncio.to_thread for DuckDB
+    symbols_needed = list({c["symbol"] for c in candidates})
+
+    def _fetch_prices_sync(syms):
+        prices = {}
+        try:
+            from app.data.duckdb_storage import duckdb_store
+            conn = duckdb_store.get_thread_cursor()
+            for sym in syms:
+                try:
+                    row = conn.execute(
+                        "SELECT close FROM daily_ohlcv WHERE symbol = ? ORDER BY date DESC LIMIT 1",
+                        [sym],
+                    ).fetchone()
+                    if row:
+                        prices[sym] = float(row[0])
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        return prices
+
+    current_prices = await asyncio.to_thread(_fetch_prices_sync, symbols_needed)
+
+    # Alpaca fallback for missing symbols
+    missing = [s for s in symbols_needed if s not in current_prices]
+    if missing:
+        try:
+            from app.services.alpaca_service import alpaca_service
+            for sym in missing:
+                try:
+                    quote = await alpaca_service.get_latest_quote(sym)
+                    if quote:
+                        ask = float(quote.get("ap", 0))
+                        bid = float(quote.get("bp", 0))
+                        if ask and bid:
+                            current_prices[sym] = (ask + bid) / 2
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    # 5. Resolve each candidate
+    for cand in candidates:
+        symbol = cand["symbol"]
+        current_price = current_prices.get(symbol)
+        if not current_price or current_price <= 0:
+            result["skipped"] += 1
+            continue
+
+        entry_price = cand["entry_price"]
+        direction = cand["direction"]
+
+        # Determine if signal direction was correct
+        if direction == "bullish":
+            outcome = 1 if current_price > entry_price else 0
+            prediction = 1
+        elif direction == "bearish":
+            outcome = 1 if current_price < entry_price else 0
+            prediction = 0
+        else:
+            result["skipped"] += 1
+            continue
+
+        try:
+            ml_record(
+                symbol=symbol,
+                signal_date=cand["signal_date"],
+                outcome=outcome,
+                prediction=prediction,
+            )
+            result["resolved"] += 1
+        except Exception as e:
+            logger.debug("resolve_historical_signals record error for %s: %s", symbol, e)
+            result["errors"] += 1
+
+    # 6. Sync flywheel_data store
+    if result["resolved"] > 0:
+        try:
+            _sync_flywheel_data_from_resolver()
+        except Exception:
+            pass
+
+    logger.info(
+        "resolve_historical_signals: resolved=%d skipped=%d errors=%d",
+        result["resolved"], result["skipped"], result["errors"],
+    )
+    return result
 
 
 # Module-level singleton

--- a/backend/app/services/unified_profit_engine.py
+++ b/backend/app/services/unified_profit_engine.py
@@ -208,6 +208,7 @@ class UnifiedProfitEngine:
             "brains_active": total_brains,
             "brain_scores": {k: round(v[0], 1) for k, v in brain_scores.items()},
             "weights": {k: round(v, 3) for k, v in self._weights.items()},
+            "price": context.get("close", context.get("price", 0)),
             "timestamp": time.time(),
         }
 


### PR DESCRIPTION
## Summary
The system was running at ~5% capacity because `LLM_ENABLED=false` blocked the entire neural architecture. This PR enables the full brain and fixes 4 critical pipeline gaps.

- **LLM_ENABLED=true** — Auto-starts CouncilGate (35-agent council), HyperSwarm (50 Ollama workers), NewsAggregator (9 RSS feeds + SEC + FRED), UnifiedProfitEngine, AutonomousScouts, MarketWideSweep
- **ATR-based signal enrichment** (#62): Pattern-aware entry/target/stop using real ATR data instead of hardcoded 3%/2%
- **Price-action regime fallback** (#60): SPY-based classifier (SMA/ATR/drawdown) when macro data unavailable
- **Flywheel wiring** (#58): OutcomeTracker → flywheel sync + hourly retroactive signal resolution
- **Pipeline gap fix** (#59): OrderExecutor subscribes to `signal.unified` + turbo direct bypass when council offline
- **10 files changed**, 804 insertions, new `price_action_regime.py` module

## What starts on restart
| Service | Was | Now |
|---------|-----|-----|
| CouncilGate (35-agent council) | OFF | ✅ Auto-start |
| HyperSwarm (Ollama micro-analysis) | OFF | ✅ Auto-start |
| NewsAggregator (RSS + SEC + FRED) | OFF | ✅ Auto-start |
| UnifiedProfitEngine (ensemble scorer) | OFF | ✅ Auto-start |
| AutonomousScouts (LLM discovery) | OFF | ✅ Auto-start |
| MarketWideSweep (8000+ symbols) | OFF | ✅ Auto-start |
| Regime detection | UNKNOWN | ✅ SPY fallback |
| Signal entry/target/stop | Hardcoded 3%/2% | ✅ ATR-based |
| Flywheel resolution | 0 resolved | ✅ Hourly auto-resolve |
| OrderExecutor signal input | council.verdict only | ✅ + signal.unified + turbo bypass |

## Test plan
- [ ] Restart backend — verify CouncilGate, HyperSwarm, NewsAggregator start in logs
- [ ] Check `/api/v1/openclaw/regime` — should return BULLISH/BEARISH/SIDEWAYS (not UNKNOWN)
- [ ] Check `/api/v1/signals/` — signals should have non-zero entry/target/stop values
- [ ] Check `/api/v1/cns/profit-brain` — news.running should be true
- [ ] POST `/api/v1/flywheel/resolve-signals` — should resolve historical signals
- [ ] Check `/api/v1/flywheel` — resolvedSignals should be > 0 after resolution
- [ ] Verify Ollama is handling council requests (watch GPU utilization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)