### PR TITLE
chore: gitignore auto-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,12 @@ htmlcov/
 .deps-hash
 .build-hash
 
+# ── Cross-PC auto-generated (Cursor/Claude Code merge conflict prevention) ──
+backend/app/modules/ml_engine/drift_log.json
+backend/app/modules/ml_engine/reference_stats.json
+backend/app/data/*.lock
+backend/app/data/*.wal
+
 # ── Misc ──
 *.bak
 *.tmp


### PR DESCRIPTION
Prevents merge conflicts between Cursor (PC1) and Claude Code (PC2) for drift_log.json, reference_stats.json, DuckDB locks, and port config.

Made with [Cursor](https://cursor.com)